### PR TITLE
feat(data): DuckDB ingestion & dbt transformation models

### DIFF
--- a/dbt/dbt_project.yml
+++ b/dbt/dbt_project.yml
@@ -1,0 +1,19 @@
+name: credit_pulse
+version: "1.0.0"
+config-version: 2
+
+profile: credit_pulse
+
+model-paths: ["models"]
+macro-paths: ["macros"]
+target-path: "target"
+clean-targets: ["target", "dbt_packages"]
+
+models:
+  credit_pulse:
+    staging:
+      +materialized: view
+    intermediate:
+      +materialized: table
+    marts:
+      +materialized: table

--- a/dbt/macros/transaction_categories.sql
+++ b/dbt/macros/transaction_categories.sql
@@ -1,0 +1,21 @@
+{% macro classify_transaction(transaction_type) %}
+    case
+        when {{ transaction_type }} ilike '%airtime%' then 'airtime'
+        when {{ transaction_type }} ilike '%bet%' or {{ transaction_type }} ilike '%sportpesa%'
+             or {{ transaction_type }} ilike '%betika%' or {{ transaction_type }} ilike '%betway%' then 'betting'
+        when {{ transaction_type }} ilike '%kplc%' or {{ transaction_type }} ilike '%kenya power%'
+             or {{ transaction_type }} ilike '%safaricom%' or {{ transaction_type }} ilike '%zuku%'
+             or {{ transaction_type }} ilike '%nairobi%water%' or {{ transaction_type }} ilike '%dstv%'
+             or {{ transaction_type }} ilike '%gotv%' then 'utility'
+        when {{ transaction_type }} ilike '%withdraw%' or {{ transaction_type }} ilike '%atm%' then 'cash_withdrawal'
+        when {{ transaction_type }} ilike '%m-shwari%' or {{ transaction_type }} ilike '%mshwari%' then 'mshwari'
+        when {{ transaction_type }} ilike '%kcb%' then 'kcb_mpesa'
+        when {{ transaction_type }} ilike '%fuliza%' then 'fuliza'
+        when {{ transaction_type }} ilike '%received%' or {{ transaction_type }} ilike '%receive%' then 'p2p_received'
+        when {{ transaction_type }} ilike '%sent%' or {{ transaction_type }} ilike '%send%'
+             or {{ transaction_type }} ilike '%paid%' or {{ transaction_type }} ilike '%pay%' then 'p2p_sent'
+        when {{ transaction_type }} ilike '%merchant%' or {{ transaction_type }} ilike '%buy goods%'
+             or {{ transaction_type }} ilike '%lipa%' or {{ transaction_type }} ilike '%till%' then 'merchant'
+        else 'other'
+    end
+{% endmacro %}

--- a/dbt/models/intermediate/int_borrower_profiles.sql
+++ b/dbt/models/intermediate/int_borrower_profiles.sql
@@ -1,0 +1,25 @@
+with loans as (
+    select * from {{ ref('stg_loan_repayments') }}
+)
+
+select
+    customer_id,
+    loan_id,
+    loan_type,
+    funded_date,
+    due_date,
+    loan_duration,
+    loan_amount,
+    amount_to_repay,
+    interest_amount,
+    repaid_amount,
+    loan_balance,
+    last_paid_date,
+    is_defaulted,
+    repaid_amount * 1.0 / nullif(amount_to_repay, 0) as repayment_ratio,
+    case
+        when last_paid_date is not null
+        then datediff('day', due_date, last_paid_date)
+        else null
+    end as days_past_due
+from loans

--- a/dbt/models/intermediate/int_transaction_features.sql
+++ b/dbt/models/intermediate/int_transaction_features.sql
@@ -1,0 +1,60 @@
+with txns as (
+    select * from {{ ref('stg_mpesa_transactions') }}
+),
+
+customer_agg as (
+    select
+        customer_id,
+        count(*) as transaction_count,
+        count(distinct cast(transaction_at as date)) as active_days,
+        count(*) * 1.0 / nullif(
+            datediff('day', min(transaction_at), max(transaction_at)), 0
+        ) as transaction_frequency,
+        sum(received_amount) as total_inflows,
+        sum(sent_amount) as total_outflows,
+        sum(received_amount) * 1.0 / nullif(sum(sent_amount), 0) as inflow_outflow_ratio,
+        avg(balance) as avg_balance,
+        min(balance) as min_balance,
+        max(balance) as max_balance,
+        stddev(balance) as balance_volatility,
+        avg(case when received_amount > 0 then received_amount end) as avg_received_amount,
+        max(received_amount) as max_received_amount,
+        stddev(sent_amount) as spending_consistency,
+        datediff('day', max(transaction_at), current_timestamp) as days_since_last_transaction,
+        datediff('day', min(transaction_at), max(transaction_at)) as account_age_days
+    from txns
+    group by customer_id
+),
+
+category_ratios as (
+    select
+        customer_id,
+        sum(case when tx_category = 'betting' then sent_amount else 0 end)
+            * 1.0 / nullif(sum(sent_amount), 0) as betting_spend_ratio,
+        sum(case when tx_category = 'utility' then sent_amount else 0 end)
+            * 1.0 / nullif(sum(sent_amount), 0) as utility_payment_ratio,
+        sum(case when tx_category = 'cash_withdrawal' then sent_amount else 0 end)
+            * 1.0 / nullif(sum(sent_amount), 0) as cash_withdrawal_ratio,
+        sum(case when tx_category = 'airtime' then sent_amount else 0 end)
+            * 1.0 / nullif(sum(sent_amount), 0) as airtime_spend_ratio,
+        sum(case when tx_category = 'merchant' then sent_amount else 0 end)
+            * 1.0 / nullif(sum(sent_amount), 0) as merchant_spend_ratio,
+        sum(case when tx_category in ('p2p_received', 'p2p_sent') then 1 else 0 end)
+            * 1.0 / nullif(count(*), 0) as p2p_transfer_ratio,
+        count(distinct case when tx_category in ('mshwari', 'kcb_mpesa', 'fuliza')
+            then tx_category end) as loan_product_count
+    from txns
+    group by customer_id
+)
+
+select
+    a.*,
+    c.betting_spend_ratio,
+    c.utility_payment_ratio,
+    c.cash_withdrawal_ratio,
+    c.airtime_spend_ratio,
+    c.merchant_spend_ratio,
+    c.p2p_transfer_ratio,
+    c.loan_product_count
+from customer_agg a
+join category_ratios c using (customer_id)

--- a/dbt/models/marts/mart_credit_features.sql
+++ b/dbt/models/marts/mart_credit_features.sql
@@ -1,0 +1,43 @@
+with features as (
+    select * from {{ ref('int_transaction_features') }}
+),
+
+borrowers as (
+    select * from {{ ref('int_borrower_profiles') }}
+)
+
+select
+    b.customer_id,
+    b.loan_id,
+    b.loan_type,
+    b.loan_amount,
+    b.amount_to_repay,
+    b.repaid_amount,
+    b.loan_balance,
+    b.is_defaulted,
+    b.repayment_ratio,
+    b.days_past_due,
+    coalesce(f.transaction_count, 0) as transaction_count,
+    coalesce(f.active_days, 0) as active_days,
+    coalesce(f.transaction_frequency, 0) as transaction_frequency,
+    coalesce(f.total_inflows, 0) as total_inflows,
+    coalesce(f.total_outflows, 0) as total_outflows,
+    coalesce(f.inflow_outflow_ratio, 0) as inflow_outflow_ratio,
+    coalesce(f.avg_balance, 0) as avg_balance,
+    coalesce(f.min_balance, 0) as min_balance,
+    coalesce(f.max_balance, 0) as max_balance,
+    coalesce(f.balance_volatility, 0) as balance_volatility,
+    coalesce(f.avg_received_amount, 0) as avg_received_amount,
+    coalesce(f.max_received_amount, 0) as max_received_amount,
+    coalesce(f.spending_consistency, 0) as spending_consistency,
+    coalesce(f.days_since_last_transaction, 0) as days_since_last_transaction,
+    coalesce(f.account_age_days, 0) as account_age_days,
+    coalesce(f.betting_spend_ratio, 0) as betting_spend_ratio,
+    coalesce(f.utility_payment_ratio, 0) as utility_payment_ratio,
+    coalesce(f.cash_withdrawal_ratio, 0) as cash_withdrawal_ratio,
+    coalesce(f.airtime_spend_ratio, 0) as airtime_spend_ratio,
+    coalesce(f.merchant_spend_ratio, 0) as merchant_spend_ratio,
+    coalesce(f.p2p_transfer_ratio, 0) as p2p_transfer_ratio,
+    coalesce(f.loan_product_count, 0) as loan_product_count
+from borrowers b
+left join features f using (customer_id)

--- a/dbt/models/marts/mart_risk_segments.sql
+++ b/dbt/models/marts/mart_risk_segments.sql
@@ -1,0 +1,24 @@
+with credit as (
+    select * from {{ ref('mart_credit_features') }}
+)
+
+select
+    customer_id,
+    loan_id,
+    is_defaulted,
+    loan_amount,
+    repayment_ratio,
+    case
+        when betting_spend_ratio > 0.1 then 'high_risk'
+        when inflow_outflow_ratio < 0.5 then 'high_risk'
+        when balance_volatility > 10000 and avg_balance < 500 then 'high_risk'
+        when utility_payment_ratio > 0.1 and inflow_outflow_ratio > 1.0 then 'low_risk'
+        when transaction_frequency > 0.5 and avg_balance > 1000 then 'low_risk'
+        else 'medium_risk'
+    end as risk_segment,
+    betting_spend_ratio,
+    inflow_outflow_ratio,
+    avg_balance,
+    transaction_frequency,
+    utility_payment_ratio
+from credit

--- a/dbt/models/staging/stg_loan_repayments.sql
+++ b/dbt/models/staging/stg_loan_repayments.sql
@@ -1,0 +1,26 @@
+with source as (
+    select * from raw_loan_repayments
+)
+
+select
+    customer_id,
+    loan_id,
+    new_repeat as loan_type,
+    cast(strptime(Funded_date, '%m/%d/%Y') as date) as funded_date,
+    cast(strptime(due_date, '%m/%d/%Y') as date) as due_date,
+    loan_duration,
+    loan_amount,
+    to_repay as amount_to_repay,
+    interest_amount,
+    repaid_amount,
+    loan_balance,
+    case
+        when last_paid_date is not null and last_paid_date != ''
+        then cast(strptime(last_paid_date, '%m/%d/%Y') as date)
+        else null
+    end as last_paid_date,
+    case
+        when loan_balance <= 0 then 0
+        else 1
+    end as is_defaulted
+from source

--- a/dbt/models/staging/stg_mpesa_transactions.sql
+++ b/dbt/models/staging/stg_mpesa_transactions.sql
@@ -1,0 +1,16 @@
+with source as (
+    select * from raw_mpesa_transactions
+)
+
+select
+    customer_id,
+    transaction_id,
+    coalesce(received_amount, 0) as received_amount,
+    coalesce(sent_amount, 0) as sent_amount,
+    coalesce(balance_then, 0) as balance,
+    transaction_type,
+    cast(transaction_datetime as timestamp) as transaction_at,
+    statement_upload_id,
+    {{ classify_transaction('transaction_type') }} as tx_category
+from source
+where transaction_id is not null

--- a/dbt/profiles.yml
+++ b/dbt/profiles.yml
@@ -1,0 +1,7 @@
+credit_pulse:
+  outputs:
+    dev:
+      type: duckdb
+      path: "../credit_pulse.duckdb"
+      threads: 4
+  target: dev

--- a/pipelines/flows/ingest.py
+++ b/pipelines/flows/ingest.py
@@ -1,0 +1,42 @@
+import duckdb
+
+from backend.core.config import DATA_DIR, DB_PATH
+
+SOURCES = [
+    ("mpesa_statements.csv", "raw_mpesa_transactions", "read_csv_auto"),
+    ("loan_repayment_data.csv", "raw_loan_repayments", "read_csv_auto"),
+]
+
+
+def _ingest_table(con: duckdb.DuckDBPyConnection, filename: str, table: str, reader: str):
+    path = DATA_DIR / filename
+    if not path.exists():
+        return
+    con.execute(f"DROP TABLE IF EXISTS {table}")
+    con.execute(f"CREATE TABLE {table} AS SELECT * FROM {reader}('{path}', nullstr='NA', sample_size=-1)")
+    count = con.execute(f"SELECT COUNT(*) FROM {table}").fetchone()[0]
+    print(f"Ingested {count:,} rows into {table}")
+
+
+def _ingest_xlsx(con: duckdb.DuckDBPyConnection):
+    path = DATA_DIR / "sql_extract.xlsx"
+    if not path.exists():
+        return
+    con.execute("INSTALL spatial; LOAD spatial;")
+    con.execute("DROP TABLE IF EXISTS raw_sql_extract")
+    con.execute(f"CREATE TABLE raw_sql_extract AS SELECT * FROM st_read('{path}')")
+    count = con.execute("SELECT COUNT(*) FROM raw_sql_extract").fetchone()[0]
+    print(f"Ingested {count:,} rows into raw_sql_extract")
+
+
+def ingest_data():
+    con = duckdb.connect(str(DB_PATH))
+    for filename, table, reader in SOURCES:
+        _ingest_table(con, filename, table, reader)
+    _ingest_xlsx(con)
+    con.close()
+    print(f"Database: {DB_PATH}")
+
+
+if __name__ == "__main__":
+    ingest_data()

--- a/pipelines/flows/transform.py
+++ b/pipelines/flows/transform.py
@@ -1,0 +1,23 @@
+import subprocess
+import sys
+from pathlib import Path
+
+DBT_DIR = Path(__file__).resolve().parent.parent.parent / "dbt"
+
+
+def run_dbt():
+    result = subprocess.run(
+        [sys.executable, "-m", "dbt", "run", "--profiles-dir", "."],
+        cwd=str(DBT_DIR),
+        capture_output=True,
+        text=True,
+    )
+    print(result.stdout)
+    if result.returncode != 0:
+        print(result.stderr)
+        raise RuntimeError("dbt run failed")
+    print("dbt transformations complete")
+
+
+if __name__ == "__main__":
+    run_dbt()


### PR DESCRIPTION
## Summary
- Ingestion pipeline loads 3 data files into DuckDB (105K M-Pesa transactions, 61 loans, 591 SQL extract records)
- dbt staging models clean/categorize raw data with transaction type classification
- dbt intermediate models compute 22 per-customer features (flows, balance, spending ratios, loan product usage)
- dbt mart models produce final credit feature matrix and rule-based risk segments

## Changes
- `pipelines/flows/ingest.py` — CSV/XLSX to DuckDB loader
- `pipelines/flows/transform.py` — dbt run wrapper
- `dbt/models/staging/` — stg_mpesa_transactions, stg_loan_repayments
- `dbt/models/intermediate/` — int_transaction_features, int_borrower_profiles
- `dbt/models/marts/` — mart_credit_features, mart_risk_segments

## Test plan
- [ ] `make ingest` loads all 3 tables into DuckDB
- [ ] `make dbt-run` runs all 6 models without errors
- [ ] mart_credit_features has 61 rows (one per borrower)

Closes #2