### PR TITLE
feat(api): FastAPI backend with scoring and analytics

### DIFF
--- a/backend/api/routes/health.py
+++ b/backend/api/routes/health.py
@@ -1,0 +1,8 @@
+from fastapi import APIRouter
+
+router = APIRouter()
+
+
+@router.get("/health")
+def health_check():
+    return {"status": "healthy"}

--- a/backend/api/routes/insights.py
+++ b/backend/api/routes/insights.py
@@ -1,0 +1,52 @@
+import json
+
+from fastapi import APIRouter, HTTPException
+
+from backend.core.config import ARTIFACTS_DIR
+from backend.services.analytics import (
+    get_betting_correlation,
+    get_overview,
+    get_repayment_distribution,
+    get_risk_segments,
+    get_transaction_patterns,
+)
+
+router = APIRouter(prefix="/api/insights", tags=["insights"])
+
+
+@router.get("/overview")
+def overview():
+    return get_overview()
+
+
+@router.get("/features")
+def feature_importance():
+    metrics_path = ARTIFACTS_DIR / "metrics.json"
+    if not metrics_path.exists():
+        raise HTTPException(status_code=503, detail="Model not trained yet.")
+    data = json.loads(metrics_path.read_text())
+    return {
+        "feature_importance": data["feature_importance"],
+        "model": data["best_model"],
+        "auc": data["full_auc"],
+    }
+
+
+@router.get("/segments")
+def risk_segments():
+    return get_risk_segments()
+
+
+@router.get("/transactions")
+def transaction_patterns():
+    return get_transaction_patterns()
+
+
+@router.get("/repayment")
+def repayment_distribution():
+    return get_repayment_distribution()
+
+
+@router.get("/betting")
+def betting_correlation():
+    return get_betting_correlation()

--- a/backend/api/routes/scoring.py
+++ b/backend/api/routes/scoring.py
@@ -1,0 +1,14 @@
+from fastapi import APIRouter, HTTPException
+
+from backend.models.schemas import ScoreRequest, ScoreResponse
+from backend.services.credit_model import predict_risk
+
+router = APIRouter(prefix="/api", tags=["scoring"])
+
+
+@router.post("/score", response_model=ScoreResponse)
+def score_borrower(request: ScoreRequest):
+    try:
+        return predict_risk(request.model_dump())
+    except FileNotFoundError:
+        raise HTTPException(status_code=503, detail="Model not trained yet. Run `make train` first.")

--- a/backend/api/routes/sql_analysis.py
+++ b/backend/api/routes/sql_analysis.py
@@ -1,0 +1,30 @@
+from fastapi import APIRouter
+
+from backend.services.analytics import (
+    sql_latest_per_user,
+    sql_records_per_day,
+    sql_top_users,
+    sql_total_records,
+)
+
+router = APIRouter(prefix="/api/sql", tags=["sql-analysis"])
+
+
+@router.get("/total")
+def total_records():
+    return sql_total_records()
+
+
+@router.get("/latest-per-user")
+def latest_per_user():
+    return sql_latest_per_user()
+
+
+@router.get("/top-users")
+def top_users():
+    return sql_top_users()
+
+
+@router.get("/records-per-day")
+def records_per_day():
+    return sql_records_per_day()

--- a/backend/main.py
+++ b/backend/main.py
@@ -1,0 +1,37 @@
+from pathlib import Path
+
+from fastapi import FastAPI, Request
+from fastapi.middleware.cors import CORSMiddleware
+from fastapi.responses import JSONResponse
+from fastapi.staticfiles import StaticFiles
+
+from backend.api.routes import health, insights, scoring, sql_analysis
+
+app = FastAPI(
+    title="Credit Pulse",
+    description="Credit risk scoring platform for M-Pesa transaction data",
+    version="0.1.0",
+)
+
+app.add_middleware(
+    CORSMiddleware,
+    allow_origins=["*"],
+    allow_credentials=True,
+    allow_methods=["*"],
+    allow_headers=["*"],
+)
+
+
+@app.exception_handler(Exception)
+async def global_exception_handler(request: Request, exc: Exception):
+    return JSONResponse(status_code=500, content={"detail": str(exc)})
+
+
+app.include_router(health.router)
+app.include_router(scoring.router)
+app.include_router(insights.router)
+app.include_router(sql_analysis.router)
+
+frontend_dist = Path(__file__).resolve().parent.parent / "frontend" / "dist"
+if frontend_dist.exists():
+    app.mount("/", StaticFiles(directory=str(frontend_dist), html=True), name="frontend")

--- a/backend/models/schemas.py
+++ b/backend/models/schemas.py
@@ -1,0 +1,43 @@
+from pydantic import BaseModel
+
+
+class ScoreRequest(BaseModel):
+    transaction_count: float = 0
+    active_days: float = 0
+    transaction_frequency: float = 0
+    total_inflows: float = 0
+    total_outflows: float = 0
+    inflow_outflow_ratio: float = 0
+    avg_balance: float = 0
+    min_balance: float = 0
+    max_balance: float = 0
+    balance_volatility: float = 0
+    avg_received_amount: float = 0
+    max_received_amount: float = 0
+    spending_consistency: float = 0
+    days_since_last_transaction: float = 0
+    account_age_days: float = 0
+    betting_spend_ratio: float = 0
+    utility_payment_ratio: float = 0
+    cash_withdrawal_ratio: float = 0
+    airtime_spend_ratio: float = 0
+    merchant_spend_ratio: float = 0
+    p2p_transfer_ratio: float = 0
+    loan_product_count: float = 0
+
+
+class ScoreResponse(BaseModel):
+    risk_score: float
+    risk_label: str
+    default_probability: float
+    model_used: str
+    top_factors: list[dict]
+
+
+class OverviewResponse(BaseModel):
+    total_borrowers: float
+    total_defaults: float
+    default_rate: float
+    avg_loan_amount: float
+    total_disbursed: float
+    avg_repayment_ratio: float

--- a/backend/services/analytics.py
+++ b/backend/services/analytics.py
@@ -1,0 +1,157 @@
+from contextlib import contextmanager
+
+import duckdb
+
+from backend.core.config import DB_PATH
+
+
+@contextmanager
+def connection():
+    con = duckdb.connect(str(DB_PATH), read_only=True)
+    try:
+        yield con
+    finally:
+        con.close()
+
+
+def _to_native(row: dict) -> dict:
+    return {k: float(v) if v is not None else 0 for k, v in row.items()}
+
+
+def get_overview() -> dict:
+    with connection() as con:
+        row = con.execute("""
+            SELECT
+                COUNT(*) as total_borrowers,
+                SUM(is_defaulted) as total_defaults,
+                AVG(is_defaulted) as default_rate,
+                AVG(loan_amount) as avg_loan_amount,
+                SUM(loan_amount) as total_disbursed,
+                AVG(repayment_ratio) as avg_repayment_ratio
+            FROM mart_credit_features
+        """).fetchdf().to_dict(orient="records")[0]
+    return _to_native(row)
+
+
+def get_risk_segments() -> list[dict]:
+    with connection() as con:
+        return con.execute("""
+            SELECT
+                risk_segment,
+                COUNT(*) as count,
+                AVG(CASE WHEN is_defaulted = 1 THEN 1.0 ELSE 0.0 END) as default_rate,
+                AVG(loan_amount) as avg_loan
+            FROM mart_risk_segments
+            GROUP BY risk_segment
+            ORDER BY risk_segment
+        """).fetchdf().to_dict(orient="records")
+
+
+def get_transaction_patterns() -> dict:
+    with connection() as con:
+        monthly = con.execute("""
+            SELECT
+                date_trunc('month', transaction_at) as month,
+                SUM(received_amount) as total_inflows,
+                SUM(sent_amount) as total_outflows,
+                COUNT(*) as tx_count
+            FROM stg_mpesa_transactions
+            GROUP BY date_trunc('month', transaction_at)
+            ORDER BY month
+        """).fetchdf()
+        monthly["month"] = monthly["month"].dt.strftime("%Y-%m")
+
+        categories = con.execute("""
+            SELECT
+                tx_category,
+                COUNT(*) as count,
+                SUM(sent_amount) as total_amount
+            FROM stg_mpesa_transactions
+            GROUP BY tx_category
+            ORDER BY total_amount DESC
+        """).fetchdf()
+
+        hourly = con.execute("""
+            SELECT
+                EXTRACT(hour FROM transaction_at) as hour,
+                COUNT(*) as count
+            FROM stg_mpesa_transactions
+            GROUP BY EXTRACT(hour FROM transaction_at)
+            ORDER BY hour
+        """).fetchdf()
+
+    return {
+        "monthly_flows": monthly.to_dict(orient="records"),
+        "categories": categories.to_dict(orient="records"),
+        "hourly_distribution": hourly.to_dict(orient="records"),
+    }
+
+
+def get_betting_correlation() -> list[dict]:
+    with connection() as con:
+        return con.execute("""
+            SELECT
+                customer_id,
+                betting_spend_ratio,
+                is_defaulted,
+                loan_amount
+            FROM mart_credit_features
+            ORDER BY betting_spend_ratio DESC
+        """).fetchdf().to_dict(orient="records")
+
+
+def get_repayment_distribution() -> list[dict]:
+    with connection() as con:
+        return con.execute("""
+            SELECT
+                CASE WHEN is_defaulted = 1 THEN 'Defaulted' ELSE 'Repaid' END as status,
+                COUNT(*) as count,
+                AVG(loan_amount) as avg_loan_amount
+            FROM mart_credit_features
+            GROUP BY is_defaulted
+        """).fetchdf().to_dict(orient="records")
+
+
+def sql_total_records() -> dict:
+    with connection() as con:
+        row = con.execute("""
+            SELECT COUNT(*) AS total_records, COUNT(DISTINCT user_id) AS distinct_users
+            FROM raw_sql_extract
+        """).fetchdf().to_dict(orient="records")[0]
+    return {k: int(v) for k, v in row.items()}
+
+
+def sql_latest_per_user() -> list[dict]:
+    with connection() as con:
+        df = con.execute("""
+            SELECT * FROM (
+                SELECT *, ROW_NUMBER() OVER (PARTITION BY user_id ORDER BY ex_date DESC) AS rn
+                FROM raw_sql_extract
+            ) WHERE rn = 1
+            ORDER BY user_id
+        """).fetchdf()
+    df = df.drop(columns=["rn"], errors="ignore")
+    return df.to_dict(orient="records")
+
+
+def sql_top_users() -> list[dict]:
+    with connection() as con:
+        return con.execute("""
+            SELECT user_id, COUNT(*) AS record_count
+            FROM raw_sql_extract
+            GROUP BY user_id
+            ORDER BY record_count DESC
+            LIMIT 5
+        """).fetchdf().to_dict(orient="records")
+
+
+def sql_records_per_day() -> list[dict]:
+    with connection() as con:
+        df = con.execute("""
+            SELECT CAST(ex_date AS DATE) AS record_date, COUNT(*) AS daily_count
+            FROM raw_sql_extract
+            GROUP BY CAST(ex_date AS DATE)
+            ORDER BY record_date
+        """).fetchdf()
+    df["record_date"] = df["record_date"].astype(str)
+    return df.to_dict(orient="records")


### PR DESCRIPTION
## Summary
- Credit risk scoring endpoint (POST /api/score) with feature contributions
- 6 analytics insight endpoints for dashboard charts
- 4 SQL analysis endpoints for Task 3 queries
- CORS, health check, auto-generated OpenAPI docs at /docs
- Static file serving for React frontend build

## Changes
- `backend/main.py` — FastAPI app with router registration
- `backend/models/schemas.py` — Pydantic request/response models
- `backend/api/routes/` — health, scoring, insights, sql_analysis routers
- `backend/services/analytics.py` — DuckDB analytics queries

## Test plan
- [ ] `make serve` starts server on port 8000
- [ ] `/health` returns OK
- [ ] `/docs` shows OpenAPI documentation
- [ ] `/api/insights/overview` returns borrower stats

Closes #5