### PR TITLE
feat(ui): React dashboard with charts and risk scorer

### DIFF
--- a/frontend/src/components/Dashboard.tsx
+++ b/frontend/src/components/Dashboard.tsx
@@ -1,0 +1,69 @@
+import { useApi } from '../hooks/useApi';
+import { api } from '../lib/api';
+import { Users, AlertTriangle, Banknote, TrendingUp } from 'lucide-react';
+import RepaymentDistribution from './charts/RepaymentDistribution';
+import FeatureImportance from './charts/FeatureImportance';
+import RiskSegments from './charts/RiskSegments';
+import TransactionFlows from './charts/TransactionFlows';
+import CategoryBreakdown from './charts/CategoryBreakdown';
+import BettingCorrelation from './charts/BettingCorrelation';
+
+function StatCard({ icon: Icon, label, value, sub, color }: { icon: React.ComponentType<{ className?: string }>; label: string; value: string; sub?: string; color: string }) {
+  return (
+    <div className="bg-white dark:bg-gray-900 rounded-2xl p-6 shadow-sm border border-gray-100 dark:border-gray-800">
+      <div className="flex items-center gap-3 mb-3">
+        <div className={`p-2.5 rounded-xl ${color}`}>
+          <Icon className="w-5 h-5 text-white" />
+        </div>
+        <span className="text-sm font-medium text-gray-500 dark:text-gray-400">{label}</span>
+      </div>
+      <p className="text-2xl font-bold text-gray-900 dark:text-white">{value}</p>
+      {sub && <p className="text-xs text-gray-400 mt-1">{sub}</p>}
+    </div>
+  );
+}
+
+export default function Dashboard() {
+  const { data: overview, loading } = useApi(api.getOverview);
+  const { data: features } = useApi(api.getFeatures);
+
+  if (loading) {
+    return (
+      <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-4 gap-4">
+        {[...Array(4)].map((_, i) => (
+          <div key={i} className="animate-pulse h-32 bg-gray-100 dark:bg-gray-800 rounded-2xl" />
+        ))}
+      </div>
+    );
+  }
+
+  return (
+    <div className="space-y-6">
+      {/* Stat cards */}
+      <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-4 gap-4">
+        <StatCard icon={Users} label="Total Borrowers" value={overview?.total_borrowers?.toFixed(0) ?? '—'} color="bg-indigo-500" />
+        <StatCard icon={AlertTriangle} label="Default Rate" value={`${((overview?.default_rate ?? 0) * 100).toFixed(1)}%`} sub={`${overview?.total_defaults?.toFixed(0) ?? 0} defaults`} color="bg-red-500" />
+        <StatCard icon={Banknote} label="Avg Loan Amount" value={`KES ${(overview?.avg_loan_amount ?? 0).toLocaleString(undefined, { maximumFractionDigits: 0 })}`} color="bg-amber-500" />
+        <StatCard icon={TrendingUp} label="Model AUC" value={features?.auc?.toFixed(3) ?? '—'} sub={features?.model?.replace(/_/g, ' ') ?? ''} color="bg-emerald-500" />
+      </div>
+
+      {/* Charts row 1 */}
+      <div className="grid grid-cols-1 lg:grid-cols-2 gap-6">
+        <RepaymentDistribution />
+        <FeatureImportance />
+      </div>
+
+      {/* Charts row 2 */}
+      <div className="grid grid-cols-1 lg:grid-cols-2 gap-6">
+        <RiskSegments />
+        <TransactionFlows />
+      </div>
+
+      {/* Charts row 3 */}
+      <div className="grid grid-cols-1 lg:grid-cols-2 gap-6">
+        <CategoryBreakdown />
+        <BettingCorrelation />
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/components/RiskScorer.tsx
+++ b/frontend/src/components/RiskScorer.tsx
@@ -1,0 +1,142 @@
+import { useState } from 'react';
+import { api } from '../lib/api';
+import { BarChart, Bar, XAxis, YAxis, ResponsiveContainer, Tooltip } from 'recharts';
+
+const FIELDS = [
+  { key: 'transaction_count', label: 'Transaction Count', default: 1500 },
+  { key: 'active_days', label: 'Active Days', default: 200 },
+  { key: 'total_inflows', label: 'Total Inflows (KES)', default: 500000 },
+  { key: 'total_outflows', label: 'Total Outflows (KES)', default: 450000 },
+  { key: 'avg_balance', label: 'Average Balance (KES)', default: 5000 },
+  { key: 'balance_volatility', label: 'Balance Volatility', default: 3000 },
+  { key: 'betting_spend_ratio', label: 'Betting Spend Ratio', default: 0.02 },
+  { key: 'utility_payment_ratio', label: 'Utility Payment Ratio', default: 0.05 },
+  { key: 'cash_withdrawal_ratio', label: 'Cash Withdrawal Ratio', default: 0.15 },
+  { key: 'p2p_transfer_ratio', label: 'P2P Transfer Ratio', default: 0.3 },
+  { key: 'loan_product_count', label: 'Loan Products Used', default: 1 },
+  { key: 'inflow_outflow_ratio', label: 'Inflow/Outflow Ratio', default: 1.1 },
+];
+
+type Result = {
+  risk_score: number;
+  risk_label: string;
+  default_probability: number;
+  model_used: string;
+  top_factors: { feature: string; value: number; importance: number }[];
+};
+
+export default function RiskScorer() {
+  const [values, setValues] = useState<Record<string, number>>(
+    Object.fromEntries(FIELDS.map((f) => [f.key, f.default]))
+  );
+  const [result, setResult] = useState<Result | null>(null);
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  const handleSubmit = async (e: React.FormEvent) => {
+    e.preventDefault();
+    setLoading(true);
+    setError(null);
+    try {
+      const res = await api.scoreRisk(values);
+      setResult(res);
+    } catch (err: unknown) {
+      setError(err instanceof Error ? err.message : 'Failed to score');
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  const riskColor = (label: string) =>
+    label === 'high' ? 'text-red-500' : label === 'medium' ? 'text-amber-500' : 'text-emerald-500';
+  const riskBg = (label: string) =>
+    label === 'high' ? 'bg-red-500' : label === 'medium' ? 'bg-amber-500' : 'bg-emerald-500';
+
+  return (
+    <div className="grid grid-cols-1 lg:grid-cols-2 gap-8">
+      {/* Input form */}
+      <div className="bg-white dark:bg-gray-900 rounded-2xl p-6 shadow-sm border border-gray-100 dark:border-gray-800">
+        <h3 className="text-lg font-semibold text-gray-900 dark:text-gray-100 mb-6">Borrower Features</h3>
+        <form onSubmit={handleSubmit} className="space-y-4">
+          <div className="grid grid-cols-1 sm:grid-cols-2 gap-3">
+            {FIELDS.map((f) => (
+              <div key={f.key}>
+                <label className="block text-xs font-medium text-gray-500 dark:text-gray-400 mb-1">{f.label}</label>
+                <input
+                  type="number"
+                  step="any"
+                  value={values[f.key]}
+                  onChange={(e) => setValues({ ...values, [f.key]: Number(e.target.value) })}
+                  className="w-full px-3 py-2 rounded-lg border border-gray-200 dark:border-gray-700 bg-gray-50 dark:bg-gray-800 text-gray-900 dark:text-gray-100 text-sm focus:ring-2 focus:ring-indigo-500 focus:border-transparent outline-none"
+                />
+              </div>
+            ))}
+          </div>
+          <button
+            type="submit"
+            disabled={loading}
+            className="w-full py-3 px-4 bg-indigo-600 hover:bg-indigo-700 text-white font-medium rounded-xl transition-colors disabled:opacity-50"
+          >
+            {loading ? 'Scoring...' : 'Calculate Risk Score'}
+          </button>
+          {error && <p className="text-sm text-red-500">{error}</p>}
+        </form>
+      </div>
+
+      {/* Result */}
+      <div className="space-y-6">
+        {result ? (
+          <>
+            {/* Score gauge */}
+            <div className="bg-white dark:bg-gray-900 rounded-2xl p-6 shadow-sm border border-gray-100 dark:border-gray-800 text-center">
+              <h3 className="text-lg font-semibold text-gray-900 dark:text-gray-100 mb-4">Risk Assessment</h3>
+              <div className="relative w-40 h-40 mx-auto mb-4">
+                <svg viewBox="0 0 100 100" className="w-full h-full -rotate-90">
+                  <circle cx="50" cy="50" r="42" fill="none" stroke="#e5e7eb" strokeWidth="8" />
+                  <circle
+                    cx="50" cy="50" r="42" fill="none"
+                    stroke={result.risk_label === 'high' ? '#ef4444' : result.risk_label === 'medium' ? '#f59e0b' : '#22c55e'}
+                    strokeWidth="8" strokeLinecap="round"
+                    strokeDasharray={`${result.risk_score * 264} 264`}
+                  />
+                </svg>
+                <div className="absolute inset-0 flex flex-col items-center justify-center">
+                  <span className="text-3xl font-bold text-gray-900 dark:text-white">{(result.risk_score * 100).toFixed(0)}</span>
+                  <span className="text-xs text-gray-500">/ 100</span>
+                </div>
+              </div>
+              <span className={`inline-block px-4 py-1.5 rounded-full text-sm font-semibold text-white ${riskBg(result.risk_label)}`}>
+                {result.risk_label.toUpperCase()} RISK
+              </span>
+              <p className="text-sm text-gray-500 mt-2">Default probability: {(result.default_probability * 100).toFixed(1)}%</p>
+              <p className="text-xs text-gray-400 mt-1">Model: {result.model_used.replace(/_/g, ' ')}</p>
+            </div>
+
+            {/* Top factors */}
+            <div className="bg-white dark:bg-gray-900 rounded-2xl p-6 shadow-sm border border-gray-100 dark:border-gray-800">
+              <h3 className="text-lg font-semibold text-gray-900 dark:text-gray-100 mb-4">Top Risk Factors</h3>
+              <ResponsiveContainer width="100%" height={280}>
+                <BarChart
+                  data={result.top_factors.slice(0, 8).map((f) => ({ name: f.feature.replace(/_/g, ' '), importance: Number(f.importance.toFixed(4)) })).reverse()}
+                  layout="vertical"
+                  margin={{ left: 120 }}
+                >
+                  <XAxis type="number" tick={{ fontSize: 11 }} />
+                  <YAxis type="category" dataKey="name" tick={{ fontSize: 11 }} width={110} />
+                  <Tooltip contentStyle={{ borderRadius: '12px', border: 'none' }} />
+                  <Bar dataKey="importance" fill="#6366f1" radius={[0, 6, 6, 0]} />
+                </BarChart>
+              </ResponsiveContainer>
+            </div>
+          </>
+        ) : (
+          <div className="bg-white dark:bg-gray-900 rounded-2xl p-12 shadow-sm border border-gray-100 dark:border-gray-800 text-center">
+            <div className="text-6xl mb-4">🎯</div>
+            <h3 className="text-lg font-semibold text-gray-900 dark:text-gray-100 mb-2">Score a Borrower</h3>
+            <p className="text-sm text-gray-500">Fill in the borrower's transaction features on the left and click "Calculate Risk Score" to get a real-time credit risk assessment.</p>
+          </div>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/components/SQLAnalysis.tsx
+++ b/frontend/src/components/SQLAnalysis.tsx
@@ -1,0 +1,100 @@
+import { useApi } from '../hooks/useApi';
+import { api } from '../lib/api';
+import { BarChart, Bar, XAxis, YAxis, ResponsiveContainer, Tooltip } from 'recharts';
+
+function Table({ headers, rows }: { headers: string[]; rows: (string | number)[][] }) {
+  return (
+    <div className="overflow-x-auto">
+      <table className="w-full text-sm">
+        <thead>
+          <tr className="border-b border-gray-200 dark:border-gray-700">
+            {headers.map((h) => (
+              <th key={h} className="text-left py-2 px-3 font-medium text-gray-500 dark:text-gray-400">{h}</th>
+            ))}
+          </tr>
+        </thead>
+        <tbody>
+          {rows.map((row, i) => (
+            <tr key={i} className="border-b border-gray-100 dark:border-gray-800 hover:bg-gray-50 dark:hover:bg-gray-800/50">
+              {row.map((cell, j) => (
+                <td key={j} className="py-2 px-3 text-gray-700 dark:text-gray-300">{typeof cell === 'number' ? cell.toLocaleString() : String(cell)}</td>
+              ))}
+            </tr>
+          ))}
+        </tbody>
+      </table>
+    </div>
+  );
+}
+
+export default function SQLAnalysis() {
+  const { data: totals, loading: l1 } = useApi(api.sqlTotal);
+  const { data: topUsers, loading: l2 } = useApi(api.sqlTopUsers);
+  const { data: perDay, loading: l3 } = useApi(api.sqlRecordsPerDay);
+  const { data: latest, loading: l4 } = useApi(api.sqlLatestPerUser);
+
+  const loading = l1 || l2 || l3 || l4;
+  if (loading) return <div className="animate-pulse h-96 bg-gray-100 dark:bg-gray-800 rounded-2xl" />;
+
+  return (
+    <div className="space-y-6">
+      {/* Query 1: Totals */}
+      <div className="bg-white dark:bg-gray-900 rounded-2xl p-6 shadow-sm border border-gray-100 dark:border-gray-800">
+        <h3 className="text-lg font-semibold text-gray-900 dark:text-gray-100 mb-2">Query 1: Total Records & Distinct Users</h3>
+        <p className="text-sm text-gray-500 dark:text-gray-400 mb-4 font-mono">SELECT COUNT(*) AS total_records, COUNT(DISTINCT user_id) AS distinct_users FROM sql_extract;</p>
+        <div className="grid grid-cols-2 gap-4">
+          <div className="bg-indigo-50 dark:bg-indigo-900/20 rounded-xl p-4 text-center">
+            <p className="text-2xl font-bold text-indigo-600 dark:text-indigo-400">{totals?.total_records?.toLocaleString()}</p>
+            <p className="text-xs text-gray-500 mt-1">Total Records</p>
+          </div>
+          <div className="bg-emerald-50 dark:bg-emerald-900/20 rounded-xl p-4 text-center">
+            <p className="text-2xl font-bold text-emerald-600 dark:text-emerald-400">{totals?.distinct_users?.toLocaleString()}</p>
+            <p className="text-xs text-gray-500 mt-1">Distinct Users</p>
+          </div>
+        </div>
+      </div>
+
+      {/* Query 3: Top 5 users */}
+      <div className="bg-white dark:bg-gray-900 rounded-2xl p-6 shadow-sm border border-gray-100 dark:border-gray-800">
+        <h3 className="text-lg font-semibold text-gray-900 dark:text-gray-100 mb-2">Query 3: Top 5 Users by Record Count</h3>
+        <p className="text-sm text-gray-500 dark:text-gray-400 mb-4 font-mono">SELECT user_id, COUNT(*) AS record_count FROM sql_extract GROUP BY user_id ORDER BY record_count DESC LIMIT 5;</p>
+        {topUsers && (
+          <Table
+            headers={['User ID', 'Record Count']}
+            rows={topUsers.map((u) => [u.user_id, u.record_count])}
+          />
+        )}
+      </div>
+
+      {/* Query 4: Records per day */}
+      <div className="bg-white dark:bg-gray-900 rounded-2xl p-6 shadow-sm border border-gray-100 dark:border-gray-800">
+        <h3 className="text-lg font-semibold text-gray-900 dark:text-gray-100 mb-2">Query 4: Records Count Per Day</h3>
+        <p className="text-sm text-gray-500 dark:text-gray-400 mb-4 font-mono">SELECT CAST(ex_date AS DATE) AS record_date, COUNT(*) AS daily_count FROM sql_extract GROUP BY ... ORDER BY record_date;</p>
+        {perDay && (
+          <ResponsiveContainer width="100%" height={250}>
+            <BarChart data={perDay}>
+              <XAxis dataKey="record_date" tick={{ fontSize: 10 }} interval="preserveStartEnd" />
+              <YAxis tick={{ fontSize: 11 }} />
+              <Tooltip contentStyle={{ borderRadius: '12px', border: 'none', boxShadow: '0 4px 20px rgba(0,0,0,.08)' }} />
+              <Bar dataKey="daily_count" fill="#6366f1" radius={[4, 4, 0, 0]} name="Records" />
+            </BarChart>
+          </ResponsiveContainer>
+        )}
+      </div>
+
+      {/* Query 2: Latest per user (table) */}
+      <div className="bg-white dark:bg-gray-900 rounded-2xl p-6 shadow-sm border border-gray-100 dark:border-gray-800">
+        <h3 className="text-lg font-semibold text-gray-900 dark:text-gray-100 mb-2">Query 2: Latest Record Per User</h3>
+        <p className="text-sm text-gray-500 dark:text-gray-400 mb-4 font-mono">SELECT * FROM (SELECT *, ROW_NUMBER() OVER (PARTITION BY user_id ORDER BY ex_date DESC) AS rn ...) WHERE rn = 1;</p>
+        {latest && latest.length > 0 && (
+          <div className="max-h-96 overflow-auto">
+            <Table
+              headers={Object.keys(latest[0])}
+              rows={latest.map((r) => Object.values(r) as (string | number)[])}
+            />
+          </div>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/components/charts/BettingCorrelation.tsx
+++ b/frontend/src/components/charts/BettingCorrelation.tsx
@@ -1,0 +1,36 @@
+import { ScatterChart, Scatter, XAxis, YAxis, ResponsiveContainer, Tooltip, Cell } from 'recharts';
+import { useApi } from '../../hooks/useApi';
+import { api } from '../../lib/api';
+
+export default function BettingCorrelation() {
+  const { data, loading } = useApi(api.getBetting);
+  if (loading || !data) return <div className="animate-pulse h-64 bg-gray-100 dark:bg-gray-800 rounded-xl" />;
+
+  const chartData = data.map((d) => ({
+    betting: Number((d.betting_spend_ratio * 100).toFixed(1)),
+    loan: d.loan_amount,
+    defaulted: d.is_defaulted,
+  }));
+
+  return (
+    <div className="bg-white dark:bg-gray-900 rounded-2xl p-6 shadow-sm border border-gray-100 dark:border-gray-800">
+      <h3 className="text-lg font-semibold text-gray-900 dark:text-gray-100 mb-4">Betting Spend vs Default</h3>
+      <ResponsiveContainer width="100%" height={280}>
+        <ScatterChart margin={{ bottom: 10 }}>
+          <XAxis dataKey="betting" name="Betting %" unit="%" tick={{ fontSize: 11 }} />
+          <YAxis dataKey="loan" name="Loan" tick={{ fontSize: 11 }} tickFormatter={(v) => `${(v / 1000).toFixed(0)}K`} />
+          <Tooltip cursor={{ strokeDasharray: '3 3' }} contentStyle={{ borderRadius: '12px', border: 'none', boxShadow: '0 4px 20px rgba(0,0,0,.08)' }} />
+          <Scatter data={chartData}>
+            {chartData.map((d, i) => (
+              <Cell key={i} fill={d.defaulted ? '#ef4444' : '#22c55e'} opacity={0.7} />
+            ))}
+          </Scatter>
+        </ScatterChart>
+      </ResponsiveContainer>
+      <div className="flex gap-4 justify-center mt-2 text-xs text-gray-500">
+        <span className="flex items-center gap-1"><span className="w-3 h-3 rounded-full bg-green-500" /> Repaid</span>
+        <span className="flex items-center gap-1"><span className="w-3 h-3 rounded-full bg-red-500" /> Defaulted</span>
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/components/charts/CategoryBreakdown.tsx
+++ b/frontend/src/components/charts/CategoryBreakdown.tsx
@@ -1,0 +1,31 @@
+import { BarChart, Bar, XAxis, YAxis, ResponsiveContainer, Tooltip } from 'recharts';
+import { useApi } from '../../hooks/useApi';
+import { api } from '../../lib/api';
+
+export default function CategoryBreakdown() {
+  const { data, loading } = useApi(api.getTransactions);
+  if (loading || !data) return <div className="animate-pulse h-64 bg-gray-100 dark:bg-gray-800 rounded-xl" />;
+
+  const chartData = data.categories
+    .filter((c) => c.total_amount > 0)
+    .slice(0, 10)
+    .map((d) => ({
+      category: d.tx_category.replace(/_/g, ' '),
+      amount: Math.round(d.total_amount),
+      count: d.count,
+    }));
+
+  return (
+    <div className="bg-white dark:bg-gray-900 rounded-2xl p-6 shadow-sm border border-gray-100 dark:border-gray-800">
+      <h3 className="text-lg font-semibold text-gray-900 dark:text-gray-100 mb-4">Transaction Categories</h3>
+      <ResponsiveContainer width="100%" height={280}>
+        <BarChart data={chartData}>
+          <XAxis dataKey="category" tick={{ fontSize: 10 }} angle={-30} textAnchor="end" height={60} />
+          <YAxis tick={{ fontSize: 11 }} tickFormatter={(v) => `${(v / 1e6).toFixed(1)}M`} />
+          <Tooltip formatter={(v: number) => `KES ${v.toLocaleString()}`} contentStyle={{ borderRadius: '12px', border: 'none', boxShadow: '0 4px 20px rgba(0,0,0,.08)' }} />
+          <Bar dataKey="amount" fill="#f59e0b" radius={[6, 6, 0, 0]} name="Total Amount (KES)" />
+        </BarChart>
+      </ResponsiveContainer>
+    </div>
+  );
+}

--- a/frontend/src/components/charts/FeatureImportance.tsx
+++ b/frontend/src/components/charts/FeatureImportance.tsx
@@ -1,0 +1,32 @@
+import { BarChart, Bar, XAxis, YAxis, ResponsiveContainer, Tooltip } from 'recharts';
+import { useApi } from '../../hooks/useApi';
+import { api } from '../../lib/api';
+
+export default function FeatureImportance() {
+  const { data, loading } = useApi(api.getFeatures);
+  if (loading || !data) return <div className="animate-pulse h-64 bg-gray-100 dark:bg-gray-800 rounded-xl" />;
+
+  const chartData = data.feature_importance.slice(0, 12).map(([name, value]) => ({
+    name: name.replace(/_/g, ' '),
+    importance: Number(value.toFixed(4)),
+  })).reverse();
+
+  return (
+    <div className="bg-white dark:bg-gray-900 rounded-2xl p-6 shadow-sm border border-gray-100 dark:border-gray-800">
+      <div className="flex items-center justify-between mb-4">
+        <h3 className="text-lg font-semibold text-gray-900 dark:text-gray-100">Feature Importance</h3>
+        <span className="text-xs font-medium px-2 py-1 rounded-full bg-indigo-50 dark:bg-indigo-900/30 text-indigo-600 dark:text-indigo-400">
+          AUC: {data.auc.toFixed(3)}
+        </span>
+      </div>
+      <ResponsiveContainer width="100%" height={360}>
+        <BarChart data={chartData} layout="vertical" margin={{ left: 120 }}>
+          <XAxis type="number" tick={{ fontSize: 11 }} />
+          <YAxis type="category" dataKey="name" tick={{ fontSize: 11 }} width={110} />
+          <Tooltip contentStyle={{ borderRadius: '12px', border: 'none', boxShadow: '0 4px 20px rgba(0,0,0,.08)' }} />
+          <Bar dataKey="importance" fill="#6366f1" radius={[0, 6, 6, 0]} />
+        </BarChart>
+      </ResponsiveContainer>
+    </div>
+  );
+}

--- a/frontend/src/components/charts/RepaymentDistribution.tsx
+++ b/frontend/src/components/charts/RepaymentDistribution.tsx
@@ -1,0 +1,25 @@
+import { PieChart, Pie, Cell, ResponsiveContainer, Legend, Tooltip } from 'recharts';
+import { useApi } from '../../hooks/useApi';
+import { api } from '../../lib/api';
+
+const COLORS = ['#22c55e', '#ef4444'];
+
+export default function RepaymentDistribution() {
+  const { data, loading } = useApi(api.getRepayment);
+  if (loading || !data) return <div className="animate-pulse h-64 bg-gray-100 dark:bg-gray-800 rounded-xl" />;
+
+  return (
+    <div className="bg-white dark:bg-gray-900 rounded-2xl p-6 shadow-sm border border-gray-100 dark:border-gray-800">
+      <h3 className="text-lg font-semibold text-gray-900 dark:text-gray-100 mb-4">Repayment Distribution</h3>
+      <ResponsiveContainer width="100%" height={280}>
+        <PieChart>
+          <Pie data={data} dataKey="count" nameKey="status" cx="50%" cy="50%" innerRadius={60} outerRadius={100} paddingAngle={4} strokeWidth={0}>
+            {data.map((_, i) => <Cell key={i} fill={COLORS[i % COLORS.length]} />)}
+          </Pie>
+          <Tooltip formatter={(value: number) => value.toLocaleString()} contentStyle={{ borderRadius: '12px', border: 'none', boxShadow: '0 4px 20px rgba(0,0,0,.08)' }} />
+          <Legend />
+        </PieChart>
+      </ResponsiveContainer>
+    </div>
+  );
+}

--- a/frontend/src/components/charts/RiskSegments.tsx
+++ b/frontend/src/components/charts/RiskSegments.tsx
@@ -1,0 +1,31 @@
+import { BarChart, Bar, XAxis, YAxis, ResponsiveContainer, Tooltip, Legend } from 'recharts';
+import { useApi } from '../../hooks/useApi';
+import { api } from '../../lib/api';
+
+export default function RiskSegments() {
+  const { data, loading } = useApi(api.getSegments);
+  if (loading || !data) return <div className="animate-pulse h-64 bg-gray-100 dark:bg-gray-800 rounded-xl" />;
+
+  const chartData = data.map((d) => ({
+    segment: d.risk_segment.replace('_', ' '),
+    count: d.count,
+    default_rate: Number((d.default_rate * 100).toFixed(1)),
+  }));
+
+  return (
+    <div className="bg-white dark:bg-gray-900 rounded-2xl p-6 shadow-sm border border-gray-100 dark:border-gray-800">
+      <h3 className="text-lg font-semibold text-gray-900 dark:text-gray-100 mb-4">Risk Segments</h3>
+      <ResponsiveContainer width="100%" height={280}>
+        <BarChart data={chartData}>
+          <XAxis dataKey="segment" tick={{ fontSize: 12 }} />
+          <YAxis yAxisId="left" tick={{ fontSize: 11 }} />
+          <YAxis yAxisId="right" orientation="right" tick={{ fontSize: 11 }} unit="%" />
+          <Tooltip contentStyle={{ borderRadius: '12px', border: 'none', boxShadow: '0 4px 20px rgba(0,0,0,.08)' }} />
+          <Legend />
+          <Bar yAxisId="left" dataKey="count" fill="#6366f1" radius={[6, 6, 0, 0]} name="Borrowers" />
+          <Bar yAxisId="right" dataKey="default_rate" fill="#ef4444" radius={[6, 6, 0, 0]} name="Default Rate %" />
+        </BarChart>
+      </ResponsiveContainer>
+    </div>
+  );
+}

--- a/frontend/src/components/charts/TransactionFlows.tsx
+++ b/frontend/src/components/charts/TransactionFlows.tsx
@@ -1,0 +1,40 @@
+import { AreaChart, Area, XAxis, YAxis, ResponsiveContainer, Tooltip, Legend } from 'recharts';
+import { useApi } from '../../hooks/useApi';
+import { api } from '../../lib/api';
+
+export default function TransactionFlows() {
+  const { data, loading } = useApi(api.getTransactions);
+  if (loading || !data) return <div className="animate-pulse h-64 bg-gray-100 dark:bg-gray-800 rounded-xl" />;
+
+  const chartData = data.monthly_flows.map((d) => ({
+    month: d.month,
+    inflows: Math.round(d.total_inflows),
+    outflows: Math.round(d.total_outflows),
+  }));
+
+  return (
+    <div className="bg-white dark:bg-gray-900 rounded-2xl p-6 shadow-sm border border-gray-100 dark:border-gray-800">
+      <h3 className="text-lg font-semibold text-gray-900 dark:text-gray-100 mb-4">Monthly Transaction Flows</h3>
+      <ResponsiveContainer width="100%" height={280}>
+        <AreaChart data={chartData}>
+          <defs>
+            <linearGradient id="inG" x1="0" y1="0" x2="0" y2="1">
+              <stop offset="5%" stopColor="#22c55e" stopOpacity={0.3} />
+              <stop offset="95%" stopColor="#22c55e" stopOpacity={0} />
+            </linearGradient>
+            <linearGradient id="outG" x1="0" y1="0" x2="0" y2="1">
+              <stop offset="5%" stopColor="#ef4444" stopOpacity={0.3} />
+              <stop offset="95%" stopColor="#ef4444" stopOpacity={0} />
+            </linearGradient>
+          </defs>
+          <XAxis dataKey="month" tick={{ fontSize: 10 }} interval="preserveStartEnd" />
+          <YAxis tick={{ fontSize: 11 }} tickFormatter={(v) => `${(v / 1e6).toFixed(1)}M`} />
+          <Tooltip formatter={(v: number) => `KES ${v.toLocaleString()}`} contentStyle={{ borderRadius: '12px', border: 'none', boxShadow: '0 4px 20px rgba(0,0,0,.08)' }} />
+          <Legend />
+          <Area type="monotone" dataKey="inflows" stroke="#22c55e" fill="url(#inG)" strokeWidth={2} name="Inflows" />
+          <Area type="monotone" dataKey="outflows" stroke="#ef4444" fill="url(#outG)" strokeWidth={2} name="Outflows" />
+        </AreaChart>
+      </ResponsiveContainer>
+    </div>
+  );
+}

--- a/frontend/src/hooks/useApi.ts
+++ b/frontend/src/hooks/useApi.ts
@@ -1,0 +1,19 @@
+import { useState, useEffect } from 'react';
+
+export function useApi<T>(fetcher: () => Promise<T>) {
+  const [data, setData] = useState<T | null>(null);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    let cancelled = false;
+    setLoading(true);
+    fetcher()
+      .then((result) => { if (!cancelled) setData(result); })
+      .catch((err) => { if (!cancelled) setError(err.message); })
+      .finally(() => { if (!cancelled) setLoading(false); });
+    return () => { cancelled = true; };
+  }, []);
+
+  return { data, loading, error };
+}

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -1,0 +1,27 @@
+const BASE = '/api';
+
+async function fetchJson<T>(url: string, init?: RequestInit): Promise<T> {
+  const res = await fetch(url, init);
+  if (!res.ok) throw new Error(`${res.status}: ${await res.text()}`);
+  return res.json();
+}
+
+export const api = {
+  getOverview: () => fetchJson<Record<string, number>>(`${BASE}/insights/overview`),
+  getFeatures: () => fetchJson<{ feature_importance: [string, number][]; model: string; auc: number }>(`${BASE}/insights/features`),
+  getSegments: () => fetchJson<{ risk_segment: string; count: number; default_rate: number; avg_loan: number }[]>(`${BASE}/insights/segments`),
+  getTransactions: () => fetchJson<{
+    monthly_flows: { month: string; total_inflows: number; total_outflows: number; tx_count: number }[];
+    categories: { tx_category: string; count: number; total_amount: number }[];
+    hourly_distribution: { hour: number; count: number }[];
+  }>(`${BASE}/insights/transactions`),
+  getRepayment: () => fetchJson<{ status: string; count: number; avg_loan_amount: number }[]>(`${BASE}/insights/repayment`),
+  getBetting: () => fetchJson<{ customer_id: number; betting_spend_ratio: number; is_defaulted: number; loan_amount: number }[]>(`${BASE}/insights/betting`),
+  scoreRisk: (data: Record<string, number>) => fetchJson<{
+    risk_score: number; risk_label: string; default_probability: number; model_used: string; top_factors: { feature: string; value: number; importance: number }[];
+  }>(`${BASE}/score`, { method: 'POST', headers: { 'Content-Type': 'application/json' }, body: JSON.stringify(data) }),
+  sqlTotal: () => fetchJson<{ total_records: number; distinct_users: number }>(`${BASE}/sql/total`),
+  sqlLatestPerUser: () => fetchJson<Record<string, unknown>[]>(`${BASE}/sql/latest-per-user`),
+  sqlTopUsers: () => fetchJson<{ user_id: number; record_count: number }[]>(`${BASE}/sql/top-users`),
+  sqlRecordsPerDay: () => fetchJson<{ record_date: string; daily_count: number }[]>(`${BASE}/sql/records-per-day`),
+};


### PR DESCRIPTION
## Summary
- Full React dashboard with 3 pages: Dashboard, Risk Scorer, SQL Analysis
- 6 chart types using Recharts: pie, bar, area, scatter, horizontal bar
- Interactive risk scorer with form input and gauge visualization
- SQL analysis with query display, tables, and daily distribution chart
- Dark/light mode, responsive layout with TailwindCSS

## Changes
- `frontend/src/components/` — Dashboard, RiskScorer, SQLAnalysis + 6 chart components
- `frontend/src/lib/api.ts` — Typed API client
- `frontend/src/hooks/useApi.ts` — Data fetching hook

## Test plan
- [ ] `cd frontend && npm run dev` starts dev server
- [ ] Dashboard renders with all chart placeholders
- [ ] Risk scorer form submits and shows results
- [ ] Dark mode toggle works

Closes #6