### PR TITLE
feat(ui): redesign frontend with Pezesha brand identity

### DIFF
--- a/frontend/index.html
+++ b/frontend/index.html
@@ -4,7 +4,10 @@
     <meta charset="UTF-8" />
     <link rel="icon" type="image/svg+xml" href="/vite.svg" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <title>frontend</title>
+    <title>CreditPulse — Pezesha</title>
+    <link rel="preconnect" href="https://fonts.googleapis.com" />
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+    <link href="https://fonts.googleapis.com/css2?family=DM+Sans:ital,opsz,wght@0,9..40,300;0,9..40,400;0,9..40,500;0,9..40,600;0,9..40,700;1,9..40,400&family=JetBrains+Mono:wght@400;500&display=swap" rel="stylesheet" />
   </head>
   <body>
     <div id="root"></div>

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -1,5 +1,5 @@
 import { useState } from 'react';
-import { LayoutDashboard, Target, Database, Moon, Sun } from 'lucide-react';
+import { LayoutDashboard, Target, Database, Moon, Sun, Activity } from 'lucide-react';
 import Dashboard from './components/Dashboard';
 import RiskScorer from './components/RiskScorer';
 import SQLAnalysis from './components/SQLAnalysis';
@@ -14,58 +14,77 @@ const NAV: { id: Page; label: string; icon: React.ComponentType<{ className?: st
 
 export default function App() {
   const [page, setPage] = useState<Page>('dashboard');
-  const [dark, setDark] = useState(false);
+  const [light, setLight] = useState(false);
 
   return (
-    <div className={dark ? 'dark' : ''}>
-      <div className="min-h-screen bg-gray-50 dark:bg-gray-950 transition-colors">
+    <div className={light ? 'light' : ''}>
+      <div className="min-h-screen bg-surface transition-colors duration-300">
+        {/* Ambient glow */}
+        <div className="fixed top-0 left-1/2 -translate-x-1/2 w-[600px] h-[300px] bg-pz-green/5 rounded-full blur-[120px] pointer-events-none" />
+
         {/* Header */}
-        <header className="sticky top-0 z-50 bg-white/80 dark:bg-gray-900/80 backdrop-blur-xl border-b border-gray-200 dark:border-gray-800">
-          <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 h-16 flex items-center justify-between">
+        <header className="sticky top-0 z-50 bg-surface-glass backdrop-blur-2xl border-b border-border-subtle">
+          <div className="max-w-[1400px] mx-auto px-6 h-14 flex items-center justify-between">
             <div className="flex items-center gap-3">
-              <div className="w-8 h-8 rounded-lg bg-gradient-to-br from-indigo-500 to-purple-600 flex items-center justify-center">
-                <span className="text-white font-bold text-sm">CP</span>
+              <div className="relative flex items-center gap-2">
+                <div className="w-7 h-7 rounded-md bg-pz-green flex items-center justify-center">
+                  <Activity className="w-4 h-4 text-white" strokeWidth={2.5} />
+                </div>
+                <span className="text-[15px] font-semibold tracking-tight text-text-primary">
+                  Credit<span className="text-pz-green">Pulse</span>
+                </span>
               </div>
-              <h1 className="text-lg font-bold text-gray-900 dark:text-white">Credit Pulse</h1>
+              <span className="hidden sm:block text-[10px] font-medium uppercase tracking-[0.15em] text-text-muted ml-3 pl-3 border-l border-border-subtle">
+                Pezesha
+              </span>
             </div>
 
-            <nav className="flex items-center gap-1">
-              {NAV.map(({ id, label, icon: Icon }) => (
-                <button
-                  key={id}
-                  onClick={() => setPage(id)}
-                  className={`flex items-center gap-2 px-4 py-2 rounded-lg text-sm font-medium transition-colors ${
-                    page === id
-                      ? 'bg-indigo-50 dark:bg-indigo-900/30 text-indigo-600 dark:text-indigo-400'
-                      : 'text-gray-600 dark:text-gray-400 hover:bg-gray-100 dark:hover:bg-gray-800'
-                  }`}
-                >
-                  <Icon className="w-4 h-4" />
-                  <span className="hidden sm:inline">{label}</span>
-                </button>
-              ))}
+            <div className="flex items-center">
+              <nav className="flex items-center bg-surface-overlay rounded-lg p-0.5 mr-3">
+                {NAV.map(({ id, label, icon: Icon }) => (
+                  <button
+                    key={id}
+                    onClick={() => setPage(id)}
+                    className={`flex items-center gap-1.5 px-3 py-1.5 rounded-md text-xs font-medium transition-all duration-200 ${
+                      page === id
+                        ? 'bg-pz-green text-white shadow-sm shadow-pz-green/25'
+                        : 'text-text-secondary hover:text-text-primary'
+                    }`}
+                  >
+                    <Icon className="w-3.5 h-3.5" />
+                    <span className="hidden sm:inline">{label}</span>
+                  </button>
+                ))}
+              </nav>
               <button
-                onClick={() => setDark(!dark)}
-                className="ml-2 p-2 rounded-lg text-gray-500 hover:bg-gray-100 dark:hover:bg-gray-800 transition-colors"
+                onClick={() => setLight(!light)}
+                className="p-1.5 rounded-md text-text-muted hover:text-text-secondary hover:bg-surface-overlay transition-colors"
               >
-                {dark ? <Sun className="w-4 h-4" /> : <Moon className="w-4 h-4" />}
+                {light ? <Moon className="w-3.5 h-3.5" /> : <Sun className="w-3.5 h-3.5" />}
               </button>
-            </nav>
+            </div>
           </div>
         </header>
 
         {/* Main content */}
-        <main className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-8">
-          {page === 'dashboard' && <Dashboard />}
-          {page === 'scorer' && <RiskScorer />}
-          {page === 'sql' && <SQLAnalysis />}
+        <main className="max-w-[1400px] mx-auto px-6 py-6">
+          <div key={page} className="animate-fade-up">
+            {page === 'dashboard' && <Dashboard />}
+            {page === 'scorer' && <RiskScorer />}
+            {page === 'sql' && <SQLAnalysis />}
+          </div>
         </main>
 
         {/* Footer */}
-        <footer className="border-t border-gray-200 dark:border-gray-800 py-4">
-          <p className="text-center text-xs text-gray-400 dark:text-gray-600">
-            Credit Pulse — Pezesha Data Engineering Assessment
-          </p>
+        <footer className="border-t border-border-subtle py-4 mt-8">
+          <div className="max-w-[1400px] mx-auto px-6 flex items-center justify-between">
+            <p className="text-[11px] text-text-muted">
+              CreditPulse &middot; Pezesha Africa Limited
+            </p>
+            <p className="text-[11px] text-text-muted">
+              Data Engineering Assessment &middot; 2026
+            </p>
+          </div>
         </footer>
       </div>
     </div>

--- a/frontend/src/components/Dashboard.tsx
+++ b/frontend/src/components/Dashboard.tsx
@@ -8,17 +8,44 @@ import TransactionFlows from './charts/TransactionFlows';
 import CategoryBreakdown from './charts/CategoryBreakdown';
 import BettingCorrelation from './charts/BettingCorrelation';
 
-function StatCard({ icon: Icon, label, value, sub, color }: { icon: React.ComponentType<{ className?: string }>; label: string; value: string; sub?: string; color: string }) {
+function StatCard({
+  icon: Icon,
+  label,
+  value,
+  sub,
+  accent,
+  delay,
+}: {
+  icon: React.ComponentType<{ className?: string }>;
+  label: string;
+  value: string;
+  sub?: string;
+  accent: string;
+  delay: number;
+}) {
   return (
-    <div className="bg-white dark:bg-gray-900 rounded-2xl p-6 shadow-sm border border-gray-100 dark:border-gray-800">
-      <div className="flex items-center gap-3 mb-3">
-        <div className={`p-2.5 rounded-xl ${color}`}>
-          <Icon className="w-5 h-5 text-white" />
-        </div>
-        <span className="text-sm font-medium text-gray-500 dark:text-gray-400">{label}</span>
+    <div
+      className="relative group bg-surface-raised rounded-xl p-5 border border-border-subtle card-hover overflow-hidden noise animate-fade-up"
+      style={{ animationDelay: `${delay}ms` }}
+    >
+      {/* Colored top edge */}
+      <div className={`absolute top-0 left-0 right-0 h-[2px] ${accent}`} />
+
+      <div className="flex items-center justify-between mb-4">
+        <span className="text-[11px] font-medium uppercase tracking-[0.12em] text-text-muted">{label}</span>
+        <Icon className="w-4 h-4 text-text-muted" />
       </div>
-      <p className="text-2xl font-bold text-gray-900 dark:text-white">{value}</p>
-      {sub && <p className="text-xs text-gray-400 mt-1">{sub}</p>}
+      <p className="text-2xl font-bold tracking-tight text-text-primary font-mono">{value}</p>
+      {sub && <p className="text-[11px] text-text-muted mt-1.5">{sub}</p>}
+    </div>
+  );
+}
+
+function SectionLabel({ children }: { children: React.ReactNode }) {
+  return (
+    <div className="flex items-center gap-3 mb-4 mt-2">
+      <div className="w-1 h-4 rounded-full bg-pz-green" />
+      <h2 className="text-xs font-semibold uppercase tracking-[0.15em] text-text-secondary">{children}</h2>
     </div>
   );
 }
@@ -31,7 +58,7 @@ export default function Dashboard() {
     return (
       <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-4 gap-4">
         {[...Array(4)].map((_, i) => (
-          <div key={i} className="animate-pulse h-32 bg-gray-100 dark:bg-gray-800 rounded-2xl" />
+          <div key={i} className="h-28 rounded-xl animate-shimmer" />
         ))}
       </div>
     );
@@ -41,28 +68,59 @@ export default function Dashboard() {
     <div className="space-y-6">
       {/* Stat cards */}
       <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-4 gap-4">
-        <StatCard icon={Users} label="Total Borrowers" value={overview?.total_borrowers?.toFixed(0) ?? '—'} color="bg-indigo-500" />
-        <StatCard icon={AlertTriangle} label="Default Rate" value={`${((overview?.default_rate ?? 0) * 100).toFixed(1)}%`} sub={`${overview?.total_defaults?.toFixed(0) ?? 0} defaults`} color="bg-red-500" />
-        <StatCard icon={Banknote} label="Avg Loan Amount" value={`KES ${(overview?.avg_loan_amount ?? 0).toLocaleString(undefined, { maximumFractionDigits: 0 })}`} color="bg-amber-500" />
-        <StatCard icon={TrendingUp} label="Model AUC" value={features?.auc?.toFixed(3) ?? '—'} sub={features?.model?.replace(/_/g, ' ') ?? ''} color="bg-emerald-500" />
+        <StatCard
+          icon={Users}
+          label="Borrowers"
+          value={overview?.total_borrowers?.toFixed(0) ?? '—'}
+          sub="Active in portfolio"
+          accent="bg-pz-green"
+          delay={0}
+        />
+        <StatCard
+          icon={AlertTriangle}
+          label="Default Rate"
+          value={`${((overview?.default_rate ?? 0) * 100).toFixed(1)}%`}
+          sub={`${overview?.total_defaults?.toFixed(0) ?? 0} borrowers defaulted`}
+          accent="bg-danger"
+          delay={60}
+        />
+        <StatCard
+          icon={Banknote}
+          label="Avg Loan"
+          value={`KES ${(overview?.avg_loan_amount ?? 0).toLocaleString(undefined, { maximumFractionDigits: 0 })}`}
+          sub={`KES ${(overview?.total_disbursed ?? 0).toLocaleString(undefined, { maximumFractionDigits: 0 })} total`}
+          accent="bg-warning"
+          delay={120}
+        />
+        <StatCard
+          icon={TrendingUp}
+          label="Model AUC"
+          value={features?.auc?.toFixed(3) ?? '—'}
+          sub={features?.model?.replace(/_/g, ' ') ?? ''}
+          accent="bg-info"
+          delay={180}
+        />
       </div>
 
-      {/* Charts row 1 */}
-      <div className="grid grid-cols-1 lg:grid-cols-2 gap-6">
+      {/* Portfolio Overview */}
+      <SectionLabel>Portfolio Overview</SectionLabel>
+      <div className="grid grid-cols-1 lg:grid-cols-2 gap-4">
         <RepaymentDistribution />
         <FeatureImportance />
       </div>
 
-      {/* Charts row 2 */}
-      <div className="grid grid-cols-1 lg:grid-cols-2 gap-6">
+      {/* Risk Analysis */}
+      <SectionLabel>Risk Analysis</SectionLabel>
+      <div className="grid grid-cols-1 lg:grid-cols-2 gap-4">
         <RiskSegments />
-        <TransactionFlows />
+        <BettingCorrelation />
       </div>
 
-      {/* Charts row 3 */}
-      <div className="grid grid-cols-1 lg:grid-cols-2 gap-6">
+      {/* Transaction Intelligence */}
+      <SectionLabel>Transaction Intelligence</SectionLabel>
+      <div className="grid grid-cols-1 lg:grid-cols-2 gap-4">
+        <TransactionFlows />
         <CategoryBreakdown />
-        <BettingCorrelation />
       </div>
     </div>
   );

--- a/frontend/src/components/RiskScorer.tsx
+++ b/frontend/src/components/RiskScorer.tsx
@@ -1,6 +1,7 @@
 import { useState } from 'react';
 import { api } from '../lib/api';
-import { BarChart, Bar, XAxis, YAxis, ResponsiveContainer, Tooltip } from 'recharts';
+import { BarChart, Bar, XAxis, YAxis, ResponsiveContainer, Tooltip, Cell } from 'recharts';
+import { Zap, Shield, AlertTriangle, Target } from 'lucide-react';
 
 const FIELDS = [
   { key: 'transaction_count', label: 'Transaction Count', default: 1500 },
@@ -25,6 +26,12 @@ type Result = {
   top_factors: { feature: string; value: number; importance: number }[];
 };
 
+const riskConfig = (label: string) => ({
+  high: { color: '#E85D5D', bg: 'bg-danger/10 border-danger/20', text: 'text-danger', icon: AlertTriangle },
+  medium: { color: '#E8A84C', bg: 'bg-warning/10 border-warning/20', text: 'text-warning', icon: Shield },
+  low: { color: '#4CB050', bg: 'bg-pz-green/10 border-pz-green/20', text: 'text-pz-green', icon: Shield },
+}[label] ?? { color: '#4CB050', bg: 'bg-pz-green/10 border-pz-green/20', text: 'text-pz-green', icon: Shield });
+
 export default function RiskScorer() {
   const [values, setValues] = useState<Record<string, number>>(
     Object.fromEntries(FIELDS.map((f) => [f.key, f.default]))
@@ -47,25 +54,31 @@ export default function RiskScorer() {
     }
   };
 
-  const riskBg = (label: string) =>
-    label === 'high' ? 'bg-red-500' : label === 'medium' ? 'bg-amber-500' : 'bg-emerald-500';
+  const config = result ? riskConfig(result.risk_label) : null;
 
   return (
-    <div className="grid grid-cols-1 lg:grid-cols-2 gap-8">
-      {/* Input form */}
-      <div className="bg-white dark:bg-gray-900 rounded-2xl p-6 shadow-sm border border-gray-100 dark:border-gray-800">
-        <h3 className="text-lg font-semibold text-gray-900 dark:text-gray-100 mb-6">Borrower Features</h3>
-        <form onSubmit={handleSubmit} className="space-y-4">
-          <div className="grid grid-cols-1 sm:grid-cols-2 gap-3">
+    <div className="grid grid-cols-1 lg:grid-cols-5 gap-4">
+      {/* Input form — 3 cols */}
+      <div className="lg:col-span-3 bg-surface-raised rounded-xl p-6 border border-border-subtle noise relative overflow-hidden">
+        <div className="absolute top-0 left-0 right-0 h-[2px] bg-pz-green" />
+        <div className="flex items-center gap-2 mb-6">
+          <Zap className="w-4 h-4 text-pz-green" />
+          <h3 className="text-sm font-semibold text-text-primary">Borrower Profile</h3>
+        </div>
+        <form onSubmit={handleSubmit} className="space-y-5">
+          <div className="grid grid-cols-2 sm:grid-cols-3 gap-3">
             {FIELDS.map((f) => (
-              <div key={f.key}>
-                <label className="block text-xs font-medium text-gray-500 dark:text-gray-400 mb-1">{f.label}</label>
+              <div key={f.key} className="group">
+                <label className="block text-[10px] font-medium uppercase tracking-[0.1em] text-text-muted mb-1.5 group-focus-within:text-pz-green transition-colors">
+                  {f.label}
+                </label>
                 <input
                   type="number"
                   step="any"
                   value={values[f.key]}
                   onChange={(e) => setValues({ ...values, [f.key]: Number(e.target.value) })}
-                  className="w-full px-3 py-2 rounded-lg border border-gray-200 dark:border-gray-700 bg-gray-50 dark:bg-gray-800 text-gray-900 dark:text-gray-100 text-sm focus:ring-2 focus:ring-indigo-500 focus:border-transparent outline-none"
+                  className="w-full px-3 py-2 rounded-lg bg-surface-overlay border border-border-subtle text-text-primary text-sm font-mono
+                    focus:border-pz-green/50 focus:ring-1 focus:ring-pz-green/20 focus:bg-surface-raised outline-none transition-all"
                 />
               </div>
             ))}
@@ -73,65 +86,117 @@ export default function RiskScorer() {
           <button
             type="submit"
             disabled={loading}
-            className="w-full py-3 px-4 bg-indigo-600 hover:bg-indigo-700 text-white font-medium rounded-xl transition-colors disabled:opacity-50"
+            className="w-full py-3 px-4 bg-pz-green hover:bg-pz-green-dark text-white text-sm font-semibold rounded-lg
+              transition-all duration-200 disabled:opacity-40 hover:shadow-lg hover:shadow-pz-green/20
+              active:scale-[0.98]"
           >
-            {loading ? 'Scoring...' : 'Calculate Risk Score'}
+            {loading ? (
+              <span className="flex items-center justify-center gap-2">
+                <span className="w-4 h-4 border-2 border-white/30 border-t-white rounded-full animate-spin" />
+                Analyzing...
+              </span>
+            ) : (
+              'Calculate Risk Score'
+            )}
           </button>
-          {error && <p className="text-sm text-red-500">{error}</p>}
+          {error && (
+            <div className="flex items-center gap-2 px-3 py-2 rounded-lg bg-danger-muted border border-danger/20">
+              <AlertTriangle className="w-3.5 h-3.5 text-danger" />
+              <p className="text-xs text-danger">{error}</p>
+            </div>
+          )}
         </form>
       </div>
 
-      {/* Result */}
-      <div className="space-y-6">
-        {result ? (
+      {/* Result — 2 cols */}
+      <div className="lg:col-span-2 space-y-4">
+        {result && config ? (
           <>
-            {/* Score gauge */}
-            <div className="bg-white dark:bg-gray-900 rounded-2xl p-6 shadow-sm border border-gray-100 dark:border-gray-800 text-center">
-              <h3 className="text-lg font-semibold text-gray-900 dark:text-gray-100 mb-4">Risk Assessment</h3>
-              <div className="relative w-40 h-40 mx-auto mb-4">
-                <svg viewBox="0 0 100 100" className="w-full h-full -rotate-90">
-                  <circle cx="50" cy="50" r="42" fill="none" stroke="#e5e7eb" strokeWidth="8" />
-                  <circle
-                    cx="50" cy="50" r="42" fill="none"
-                    stroke={result.risk_label === 'high' ? '#ef4444' : result.risk_label === 'medium' ? '#f59e0b' : '#22c55e'}
-                    strokeWidth="8" strokeLinecap="round"
-                    strokeDasharray={`${result.risk_score * 264} 264`}
-                  />
-                </svg>
-                <div className="absolute inset-0 flex flex-col items-center justify-center">
-                  <span className="text-3xl font-bold text-gray-900 dark:text-white">{(result.risk_score * 100).toFixed(0)}</span>
-                  <span className="text-xs text-gray-500">/ 100</span>
+            {/* Score display */}
+            <div className="bg-surface-raised rounded-xl p-6 border border-border-subtle noise relative overflow-hidden animate-fade-up">
+              <div className={`absolute top-0 left-0 right-0 h-[2px]`} style={{ background: config.color }} />
+              <div className="text-center">
+                <p className="text-[10px] font-medium uppercase tracking-[0.15em] text-text-muted mb-4">Risk Assessment</p>
+
+                {/* Score gauge */}
+                <div className="relative w-36 h-36 mx-auto mb-4">
+                  <svg viewBox="0 0 100 100" className="w-full h-full -rotate-90">
+                    <circle cx="50" cy="50" r="42" fill="none" stroke="var(--color-border-subtle)" strokeWidth="6" />
+                    <circle
+                      cx="50" cy="50" r="42" fill="none"
+                      stroke={config.color}
+                      strokeWidth="6" strokeLinecap="round"
+                      strokeDasharray={`${result.risk_score * 264} 264`}
+                      style={{ transition: 'stroke-dasharray 0.8s ease-out' }}
+                    />
+                  </svg>
+                  <div className="absolute inset-0 flex flex-col items-center justify-center">
+                    <span className="text-3xl font-bold font-mono text-text-primary">{(result.risk_score * 100).toFixed(0)}</span>
+                    <span className="text-[10px] text-text-muted font-mono">/ 100</span>
+                  </div>
+                </div>
+
+                {/* Risk badge */}
+                <div className={`inline-flex items-center gap-1.5 px-3 py-1.5 rounded-full border ${config.bg}`}>
+                  <config.icon className={`w-3 h-3 ${config.text}`} />
+                  <span className={`text-xs font-bold uppercase tracking-wider ${config.text}`}>
+                    {result.risk_label} Risk
+                  </span>
+                </div>
+
+                <div className="mt-4 space-y-1">
+                  <p className="text-xs text-text-secondary">
+                    Default probability: <span className="font-mono font-medium text-text-primary">{(result.default_probability * 100).toFixed(1)}%</span>
+                  </p>
+                  <p className="text-[11px] text-text-muted">
+                    Model: {result.model_used.replace(/_/g, ' ')}
+                  </p>
                 </div>
               </div>
-              <span className={`inline-block px-4 py-1.5 rounded-full text-sm font-semibold text-white ${riskBg(result.risk_label)}`}>
-                {result.risk_label.toUpperCase()} RISK
-              </span>
-              <p className="text-sm text-gray-500 mt-2">Default probability: {(result.default_probability * 100).toFixed(1)}%</p>
-              <p className="text-xs text-gray-400 mt-1">Model: {result.model_used.replace(/_/g, ' ')}</p>
             </div>
 
             {/* Top factors */}
-            <div className="bg-white dark:bg-gray-900 rounded-2xl p-6 shadow-sm border border-gray-100 dark:border-gray-800">
-              <h3 className="text-lg font-semibold text-gray-900 dark:text-gray-100 mb-4">Top Risk Factors</h3>
-              <ResponsiveContainer width="100%" height={280}>
+            <div className="bg-surface-raised rounded-xl p-5 border border-border-subtle noise relative overflow-hidden animate-fade-up" style={{ animationDelay: '100ms' }}>
+              <div className="absolute top-0 left-0 right-0 h-[2px] bg-border-accent" />
+              <p className="text-[10px] font-medium uppercase tracking-[0.15em] text-text-muted mb-3">Contributing Factors</p>
+              <ResponsiveContainer width="100%" height={240}>
                 <BarChart
-                  data={result.top_factors.slice(0, 8).map((f) => ({ name: f.feature.replace(/_/g, ' '), importance: Number(f.importance.toFixed(4)) })).reverse()}
+                  data={result.top_factors.slice(0, 8).map((f) => ({
+                    name: f.feature.replace(/_/g, ' '),
+                    importance: Number(f.importance.toFixed(4)),
+                  })).reverse()}
                   layout="vertical"
-                  margin={{ left: 120 }}
+                  margin={{ left: 100, right: 8 }}
                 >
-                  <XAxis type="number" tick={{ fontSize: 11 }} />
-                  <YAxis type="category" dataKey="name" tick={{ fontSize: 11 }} width={110} />
-                  <Tooltip contentStyle={{ borderRadius: '12px', border: 'none' }} />
-                  <Bar dataKey="importance" fill="#6366f1" radius={[0, 6, 6, 0]} />
+                  <XAxis type="number" tick={{ fontSize: 10, fill: 'var(--color-text-muted)' }} axisLine={false} tickLine={false} />
+                  <YAxis type="category" dataKey="name" tick={{ fontSize: 10, fill: 'var(--color-text-secondary)' }} width={95} axisLine={false} tickLine={false} />
+                  <Tooltip
+                    contentStyle={{
+                      background: 'var(--color-surface-raised)',
+                      border: '1px solid var(--color-border-subtle)',
+                      borderRadius: '8px',
+                      fontSize: '11px',
+                      color: 'var(--color-text-primary)',
+                    }}
+                  />
+                  <Bar dataKey="importance" radius={[0, 4, 4, 0]}>
+                    {result.top_factors.slice(0, 8).reverse().map((_, i) => (
+                      <Cell key={i} fill={`rgba(76, 176, 80, ${0.4 + (i / 8) * 0.6})`} />
+                    ))}
+                  </Bar>
                 </BarChart>
               </ResponsiveContainer>
             </div>
           </>
         ) : (
-          <div className="bg-white dark:bg-gray-900 rounded-2xl p-12 shadow-sm border border-gray-100 dark:border-gray-800 text-center">
-            <div className="text-6xl mb-4">🎯</div>
-            <h3 className="text-lg font-semibold text-gray-900 dark:text-gray-100 mb-2">Score a Borrower</h3>
-            <p className="text-sm text-gray-500">Fill in the borrower's transaction features on the left and click "Calculate Risk Score" to get a real-time credit risk assessment.</p>
+          <div className="bg-surface-raised rounded-xl p-10 border border-border-subtle border-dashed text-center noise relative overflow-hidden h-full flex flex-col items-center justify-center">
+            <div className="w-14 h-14 rounded-2xl bg-pz-green/10 flex items-center justify-center mb-4">
+              <Target className="w-7 h-7 text-pz-green" />
+            </div>
+            <h3 className="text-sm font-semibold text-text-primary mb-2">Score a Borrower</h3>
+            <p className="text-xs text-text-muted max-w-[240px] leading-relaxed">
+              Fill in the M-Pesa transaction features and click calculate to get a real-time credit risk assessment.
+            </p>
           </div>
         )}
       </div>

--- a/frontend/src/components/SQLAnalysis.tsx
+++ b/frontend/src/components/SQLAnalysis.tsx
@@ -1,28 +1,49 @@
 import { useApi } from '../hooks/useApi';
 import { api } from '../lib/api';
 import { BarChart, Bar, XAxis, YAxis, ResponsiveContainer, Tooltip } from 'recharts';
+import { Terminal, Hash, Clock } from 'lucide-react';
 
 function Table({ headers, rows }: { headers: string[]; rows: (string | number)[][] }) {
   return (
     <div className="overflow-x-auto">
-      <table className="w-full text-sm">
+      <table className="w-full text-xs">
         <thead>
-          <tr className="border-b border-gray-200 dark:border-gray-700">
+          <tr className="border-b border-border-accent">
             {headers.map((h) => (
-              <th key={h} className="text-left py-2 px-3 font-medium text-gray-500 dark:text-gray-400">{h}</th>
+              <th key={h} className="text-left py-2.5 px-3 text-[10px] font-semibold uppercase tracking-[0.1em] text-text-muted">{h}</th>
             ))}
           </tr>
         </thead>
         <tbody>
           {rows.map((row, i) => (
-            <tr key={i} className="border-b border-gray-100 dark:border-gray-800 hover:bg-gray-50 dark:hover:bg-gray-800/50">
+            <tr key={i} className="border-b border-border-subtle hover:bg-surface-overlay/50 transition-colors">
               {row.map((cell, j) => (
-                <td key={j} className="py-2 px-3 text-gray-700 dark:text-gray-300">{typeof cell === 'number' ? cell.toLocaleString() : String(cell)}</td>
+                <td key={j} className="py-2 px-3 text-text-secondary font-mono text-xs">
+                  {typeof cell === 'number' ? cell.toLocaleString() : String(cell)}
+                </td>
               ))}
             </tr>
           ))}
         </tbody>
       </table>
+    </div>
+  );
+}
+
+function QueryCard({ number, title, sql, children }: { number: number; title: string; sql: string; children: React.ReactNode }) {
+  return (
+    <div className="bg-surface-raised rounded-xl border border-border-subtle noise relative overflow-hidden animate-fade-up" style={{ animationDelay: `${number * 80}ms` }}>
+      <div className="absolute top-0 left-0 right-0 h-[2px] bg-pz-green" />
+      <div className="p-5">
+        <div className="flex items-center gap-2 mb-1">
+          <span className="text-[10px] font-bold text-pz-green font-mono">Q{number}</span>
+          <h3 className="text-sm font-semibold text-text-primary">{title}</h3>
+        </div>
+        <div className="mt-2 mb-4 px-3 py-2 rounded-md bg-surface-overlay border border-border-subtle">
+          <code className="text-[11px] text-text-muted font-mono leading-relaxed block whitespace-pre-wrap">{sql}</code>
+        </div>
+        {children}
+      </div>
     </div>
   );
 }
@@ -34,67 +55,109 @@ export default function SQLAnalysis() {
   const { data: latest, loading: l4 } = useApi(api.sqlLatestPerUser);
 
   const loading = l1 || l2 || l3 || l4;
-  if (loading) return <div className="animate-pulse h-96 bg-gray-100 dark:bg-gray-800 rounded-2xl" />;
+  if (loading) {
+    return (
+      <div className="space-y-4">
+        {[...Array(4)].map((_, i) => (
+          <div key={i} className="h-48 rounded-xl animate-shimmer" />
+        ))}
+      </div>
+    );
+  }
 
   return (
-    <div className="space-y-6">
+    <div className="space-y-4">
+      <div className="flex items-center gap-2 mb-2">
+        <Terminal className="w-4 h-4 text-pz-green" />
+        <h2 className="text-xs font-semibold uppercase tracking-[0.15em] text-text-secondary">SQL Extract Analysis</h2>
+        <span className="text-[10px] text-text-muted ml-auto font-mono">sql_extract.xlsx &middot; DuckDB</span>
+      </div>
+
       {/* Query 1: Totals */}
-      <div className="bg-white dark:bg-gray-900 rounded-2xl p-6 shadow-sm border border-gray-100 dark:border-gray-800">
-        <h3 className="text-lg font-semibold text-gray-900 dark:text-gray-100 mb-2">Query 1: Total Records & Distinct Users</h3>
-        <p className="text-sm text-gray-500 dark:text-gray-400 mb-4 font-mono">SELECT COUNT(*) AS total_records, COUNT(DISTINCT user_id) AS distinct_users FROM sql_extract;</p>
-        <div className="grid grid-cols-2 gap-4">
-          <div className="bg-indigo-50 dark:bg-indigo-900/20 rounded-xl p-4 text-center">
-            <p className="text-2xl font-bold text-indigo-600 dark:text-indigo-400">{totals?.total_records?.toLocaleString()}</p>
-            <p className="text-xs text-gray-500 mt-1">Total Records</p>
+      <QueryCard
+        number={1}
+        title="Total Records & Distinct Users"
+        sql="SELECT COUNT(*) AS total_records, COUNT(DISTINCT user_id) AS distinct_users FROM raw_sql_extract;"
+      >
+        <div className="grid grid-cols-2 gap-3">
+          <div className="flex items-center gap-3 px-4 py-3 rounded-lg bg-pz-green/8 border border-pz-green/15">
+            <Hash className="w-4 h-4 text-pz-green shrink-0" />
+            <div>
+              <p className="text-xl font-bold font-mono text-text-primary">{totals?.total_records?.toLocaleString()}</p>
+              <p className="text-[10px] text-text-muted uppercase tracking-wider">Total Records</p>
+            </div>
           </div>
-          <div className="bg-emerald-50 dark:bg-emerald-900/20 rounded-xl p-4 text-center">
-            <p className="text-2xl font-bold text-emerald-600 dark:text-emerald-400">{totals?.distinct_users?.toLocaleString()}</p>
-            <p className="text-xs text-gray-500 mt-1">Distinct Users</p>
+          <div className="flex items-center gap-3 px-4 py-3 rounded-lg bg-info/8 border border-info/15">
+            <Hash className="w-4 h-4 text-info shrink-0" />
+            <div>
+              <p className="text-xl font-bold font-mono text-text-primary">{totals?.distinct_users?.toLocaleString()}</p>
+              <p className="text-[10px] text-text-muted uppercase tracking-wider">Distinct Users</p>
+            </div>
           </div>
         </div>
-      </div>
+      </QueryCard>
 
-      {/* Query 3: Top 5 users */}
-      <div className="bg-white dark:bg-gray-900 rounded-2xl p-6 shadow-sm border border-gray-100 dark:border-gray-800">
-        <h3 className="text-lg font-semibold text-gray-900 dark:text-gray-100 mb-2">Query 3: Top 5 Users by Record Count</h3>
-        <p className="text-sm text-gray-500 dark:text-gray-400 mb-4 font-mono">SELECT user_id, COUNT(*) AS record_count FROM sql_extract GROUP BY user_id ORDER BY record_count DESC LIMIT 5;</p>
-        {topUsers && (
-          <Table
-            headers={['User ID', 'Record Count']}
-            rows={topUsers.map((u) => [u.user_id, u.record_count])}
-          />
-        )}
-      </div>
-
-      {/* Query 4: Records per day */}
-      <div className="bg-white dark:bg-gray-900 rounded-2xl p-6 shadow-sm border border-gray-100 dark:border-gray-800">
-        <h3 className="text-lg font-semibold text-gray-900 dark:text-gray-100 mb-2">Query 4: Records Count Per Day</h3>
-        <p className="text-sm text-gray-500 dark:text-gray-400 mb-4 font-mono">SELECT CAST(ex_date AS DATE) AS record_date, COUNT(*) AS daily_count FROM sql_extract GROUP BY ... ORDER BY record_date;</p>
-        {perDay && (
-          <ResponsiveContainer width="100%" height={250}>
-            <BarChart data={perDay}>
-              <XAxis dataKey="record_date" tick={{ fontSize: 10 }} interval="preserveStartEnd" />
-              <YAxis tick={{ fontSize: 11 }} />
-              <Tooltip contentStyle={{ borderRadius: '12px', border: 'none', boxShadow: '0 4px 20px rgba(0,0,0,.08)' }} />
-              <Bar dataKey="daily_count" fill="#6366f1" radius={[4, 4, 0, 0]} name="Records" />
-            </BarChart>
-          </ResponsiveContainer>
-        )}
-      </div>
-
-      {/* Query 2: Latest per user (table) */}
-      <div className="bg-white dark:bg-gray-900 rounded-2xl p-6 shadow-sm border border-gray-100 dark:border-gray-800">
-        <h3 className="text-lg font-semibold text-gray-900 dark:text-gray-100 mb-2">Query 2: Latest Record Per User</h3>
-        <p className="text-sm text-gray-500 dark:text-gray-400 mb-4 font-mono">SELECT * FROM (SELECT *, ROW_NUMBER() OVER (PARTITION BY user_id ORDER BY ex_date DESC) AS rn ...) WHERE rn = 1;</p>
+      {/* Query 2: Latest per user */}
+      <QueryCard
+        number={2}
+        title="Latest Record Per User"
+        sql="SELECT * FROM (SELECT *, ROW_NUMBER() OVER (PARTITION BY user_id ORDER BY ex_date DESC) AS rn FROM raw_sql_extract) WHERE rn = 1;"
+      >
         {latest && latest.length > 0 && (
-          <div className="max-h-96 overflow-auto">
+          <div className="max-h-80 overflow-auto rounded-lg border border-border-subtle">
             <Table
               headers={Object.keys(latest[0])}
               rows={latest.map((r) => Object.values(r) as (string | number)[])}
             />
           </div>
         )}
-      </div>
+      </QueryCard>
+
+      {/* Query 3: Top 5 users */}
+      <QueryCard
+        number={3}
+        title="Top 5 Users by Record Count"
+        sql="SELECT user_id, COUNT(*) AS record_count FROM raw_sql_extract GROUP BY user_id ORDER BY record_count DESC LIMIT 5;"
+      >
+        {topUsers && (
+          <div className="rounded-lg border border-border-subtle overflow-hidden">
+            <Table
+              headers={['User ID', 'Record Count']}
+              rows={topUsers.map((u) => [u.user_id, u.record_count])}
+            />
+          </div>
+        )}
+      </QueryCard>
+
+      {/* Query 4: Records per day */}
+      <QueryCard
+        number={4}
+        title="Records Count Per Day"
+        sql="SELECT CAST(ex_date AS DATE) AS record_date, COUNT(*) AS daily_count FROM raw_sql_extract GROUP BY 1 ORDER BY record_date;"
+      >
+        <div className="flex items-center gap-1.5 mb-2">
+          <Clock className="w-3 h-3 text-text-muted" />
+          <span className="text-[10px] text-text-muted">Daily distribution</span>
+        </div>
+        {perDay && (
+          <ResponsiveContainer width="100%" height={220}>
+            <BarChart data={perDay}>
+              <XAxis dataKey="record_date" tick={{ fontSize: 9, fill: 'var(--color-text-muted)' }} interval="preserveStartEnd" axisLine={false} tickLine={false} />
+              <YAxis tick={{ fontSize: 10, fill: 'var(--color-text-muted)' }} axisLine={false} tickLine={false} />
+              <Tooltip
+                contentStyle={{
+                  background: 'var(--color-surface-raised)',
+                  border: '1px solid var(--color-border-subtle)',
+                  borderRadius: '8px',
+                  fontSize: '11px',
+                  color: 'var(--color-text-primary)',
+                }}
+              />
+              <Bar dataKey="daily_count" fill="#4CB050" radius={[3, 3, 0, 0]} name="Records" opacity={0.85} />
+            </BarChart>
+          </ResponsiveContainer>
+        )}
+      </QueryCard>
     </div>
   );
 }

--- a/frontend/src/components/charts/BettingCorrelation.tsx
+++ b/frontend/src/components/charts/BettingCorrelation.tsx
@@ -4,7 +4,7 @@ import { api } from '../../lib/api';
 
 export default function BettingCorrelation() {
   const { data, loading } = useApi(api.getBetting);
-  if (loading || !data) return <div className="animate-pulse h-64 bg-gray-100 dark:bg-gray-800 rounded-xl" />;
+  if (loading || !data) return <div className="h-72 rounded-xl animate-shimmer" />;
 
   const chartData = data.map((d) => ({
     betting: Number((d.betting_spend_ratio * 100).toFixed(1)),
@@ -13,24 +13,40 @@ export default function BettingCorrelation() {
   }));
 
   return (
-    <div className="bg-white dark:bg-gray-900 rounded-2xl p-6 shadow-sm border border-gray-100 dark:border-gray-800">
-      <h3 className="text-lg font-semibold text-gray-900 dark:text-gray-100 mb-4">Betting Spend vs Default</h3>
-      <ResponsiveContainer width="100%" height={280}>
-        <ScatterChart margin={{ bottom: 10 }}>
-          <XAxis dataKey="betting" name="Betting %" unit="%" tick={{ fontSize: 11 }} />
-          <YAxis dataKey="loan" name="Loan" tick={{ fontSize: 11 }} tickFormatter={(v) => `${(v / 1000).toFixed(0)}K`} />
-          <Tooltip cursor={{ strokeDasharray: '3 3' }} contentStyle={{ borderRadius: '12px', border: 'none', boxShadow: '0 4px 20px rgba(0,0,0,.08)' }} />
+    <div className="bg-surface-raised rounded-xl p-5 border border-border-subtle noise relative overflow-hidden card-hover">
+      <div className="absolute top-0 left-0 right-0 h-[2px] bg-danger" />
+      <div className="flex items-center justify-between mb-4">
+        <p className="text-[10px] font-semibold uppercase tracking-[0.15em] text-text-muted">Betting Spend vs Default</p>
+        <div className="flex gap-3">
+          <span className="flex items-center gap-1.5 text-[10px] text-text-muted">
+            <span className="w-2 h-2 rounded-full bg-pz-green" /> Repaid
+          </span>
+          <span className="flex items-center gap-1.5 text-[10px] text-text-muted">
+            <span className="w-2 h-2 rounded-full bg-danger" /> Defaulted
+          </span>
+        </div>
+      </div>
+      <ResponsiveContainer width="100%" height={260}>
+        <ScatterChart margin={{ bottom: 10, left: 0 }}>
+          <XAxis dataKey="betting" name="Betting %" unit="%" tick={{ fontSize: 10, fill: 'var(--color-text-muted)' }} axisLine={false} tickLine={false} />
+          <YAxis dataKey="loan" name="Loan" tick={{ fontSize: 10, fill: 'var(--color-text-muted)' }} tickFormatter={(v) => `${(v / 1000).toFixed(0)}K`} axisLine={false} tickLine={false} />
+          <Tooltip
+            cursor={{ strokeDasharray: '3 3', stroke: 'var(--color-border-accent)' }}
+            contentStyle={{
+              background: 'var(--color-surface-raised)',
+              border: '1px solid var(--color-border-subtle)',
+              borderRadius: '8px',
+              fontSize: '11px',
+              color: 'var(--color-text-primary)',
+            }}
+          />
           <Scatter data={chartData}>
             {chartData.map((d, i) => (
-              <Cell key={i} fill={d.defaulted ? '#ef4444' : '#22c55e'} opacity={0.7} />
+              <Cell key={i} fill={d.defaulted ? '#E85D5D' : '#4CB050'} opacity={0.65} r={5} />
             ))}
           </Scatter>
         </ScatterChart>
       </ResponsiveContainer>
-      <div className="flex gap-4 justify-center mt-2 text-xs text-gray-500">
-        <span className="flex items-center gap-1"><span className="w-3 h-3 rounded-full bg-green-500" /> Repaid</span>
-        <span className="flex items-center gap-1"><span className="w-3 h-3 rounded-full bg-red-500" /> Defaulted</span>
-      </div>
     </div>
   );
 }

--- a/frontend/src/components/charts/CategoryBreakdown.tsx
+++ b/frontend/src/components/charts/CategoryBreakdown.tsx
@@ -1,10 +1,24 @@
-import { BarChart, Bar, XAxis, YAxis, ResponsiveContainer, Tooltip } from 'recharts';
+import { BarChart, Bar, XAxis, YAxis, ResponsiveContainer, Tooltip, Cell } from 'recharts';
 import { useApi } from '../../hooks/useApi';
 import { api } from '../../lib/api';
 
+const CATEGORY_COLORS: Record<string, string> = {
+  'p2p sent': '#4CB050',
+  'p2p received': '#6ECF72',
+  'cash withdrawal': '#E8A84C',
+  'merchant': '#4C9BE8',
+  'betting': '#E85D5D',
+  'airtime': '#A78BFA',
+  'utility': '#2DD4BF',
+  'mshwari': '#F472B6',
+  'kcb mpesa': '#FB923C',
+  'fuliza': '#94A3B8',
+  'other': '#6D6E71',
+};
+
 export default function CategoryBreakdown() {
   const { data, loading } = useApi(api.getTransactions);
-  if (loading || !data) return <div className="animate-pulse h-64 bg-gray-100 dark:bg-gray-800 rounded-xl" />;
+  if (loading || !data) return <div className="h-72 rounded-xl animate-shimmer" />;
 
   const chartData = data.categories
     .filter((c) => c.total_amount > 0)
@@ -16,14 +30,28 @@ export default function CategoryBreakdown() {
     }));
 
   return (
-    <div className="bg-white dark:bg-gray-900 rounded-2xl p-6 shadow-sm border border-gray-100 dark:border-gray-800">
-      <h3 className="text-lg font-semibold text-gray-900 dark:text-gray-100 mb-4">Transaction Categories</h3>
-      <ResponsiveContainer width="100%" height={280}>
+    <div className="bg-surface-raised rounded-xl p-5 border border-border-subtle noise relative overflow-hidden card-hover">
+      <div className="absolute top-0 left-0 right-0 h-[2px] bg-warning" />
+      <p className="text-[10px] font-semibold uppercase tracking-[0.15em] text-text-muted mb-4">Transaction Categories</p>
+      <ResponsiveContainer width="100%" height={260}>
         <BarChart data={chartData}>
-          <XAxis dataKey="category" tick={{ fontSize: 10 }} angle={-30} textAnchor="end" height={60} />
-          <YAxis tick={{ fontSize: 11 }} tickFormatter={(v) => `${(v / 1e6).toFixed(1)}M`} />
-          <Tooltip formatter={(v) => `KES ${Number(v).toLocaleString()}`} contentStyle={{ borderRadius: '12px', border: 'none', boxShadow: '0 4px 20px rgba(0,0,0,.08)' }} />
-          <Bar dataKey="amount" fill="#f59e0b" radius={[6, 6, 0, 0]} name="Total Amount (KES)" />
+          <XAxis dataKey="category" tick={{ fontSize: 9, fill: 'var(--color-text-muted)' }} angle={-35} textAnchor="end" height={60} axisLine={false} tickLine={false} />
+          <YAxis tick={{ fontSize: 10, fill: 'var(--color-text-muted)' }} tickFormatter={(v) => `${(v / 1e6).toFixed(1)}M`} axisLine={false} tickLine={false} />
+          <Tooltip
+            formatter={(v) => `KES ${Number(v).toLocaleString()}`}
+            contentStyle={{
+              background: 'var(--color-surface-raised)',
+              border: '1px solid var(--color-border-subtle)',
+              borderRadius: '8px',
+              fontSize: '11px',
+              color: 'var(--color-text-primary)',
+            }}
+          />
+          <Bar dataKey="amount" radius={[4, 4, 0, 0]} name="Total Amount (KES)">
+            {chartData.map((entry, i) => (
+              <Cell key={i} fill={CATEGORY_COLORS[entry.category] ?? '#6D6E71'} opacity={0.85} />
+            ))}
+          </Bar>
         </BarChart>
       </ResponsiveContainer>
     </div>

--- a/frontend/src/components/charts/FeatureImportance.tsx
+++ b/frontend/src/components/charts/FeatureImportance.tsx
@@ -1,30 +1,45 @@
-import { BarChart, Bar, XAxis, YAxis, ResponsiveContainer, Tooltip } from 'recharts';
+import { BarChart, Bar, XAxis, YAxis, ResponsiveContainer, Tooltip, Cell } from 'recharts';
 import { useApi } from '../../hooks/useApi';
 import { api } from '../../lib/api';
 
 export default function FeatureImportance() {
   const { data, loading } = useApi(api.getFeatures);
-  if (loading || !data) return <div className="animate-pulse h-64 bg-gray-100 dark:bg-gray-800 rounded-xl" />;
+  if (loading || !data) return <div className="h-72 rounded-xl animate-shimmer" />;
 
-  const chartData = data.feature_importance.slice(0, 12).map(([name, value]) => ({
+  const chartData = data.feature_importance.slice(0, 10).map(([name, value]) => ({
     name: name.replace(/_/g, ' '),
     importance: Number(value.toFixed(4)),
   })).reverse();
 
+  const maxVal = Math.max(...chartData.map(d => d.importance));
+
   return (
-    <div className="bg-white dark:bg-gray-900 rounded-2xl p-6 shadow-sm border border-gray-100 dark:border-gray-800">
+    <div className="bg-surface-raised rounded-xl p-5 border border-border-subtle noise relative overflow-hidden card-hover">
+      <div className="absolute top-0 left-0 right-0 h-[2px] bg-pz-green" />
       <div className="flex items-center justify-between mb-4">
-        <h3 className="text-lg font-semibold text-gray-900 dark:text-gray-100">Feature Importance</h3>
-        <span className="text-xs font-medium px-2 py-1 rounded-full bg-indigo-50 dark:bg-indigo-900/30 text-indigo-600 dark:text-indigo-400">
-          AUC: {data.auc.toFixed(3)}
+        <p className="text-[10px] font-semibold uppercase tracking-[0.15em] text-text-muted">Feature Importance</p>
+        <span className="text-[10px] font-mono font-medium px-2 py-0.5 rounded-md bg-pz-green/10 text-pz-green border border-pz-green/20">
+          AUC {data.auc.toFixed(3)}
         </span>
       </div>
-      <ResponsiveContainer width="100%" height={360}>
-        <BarChart data={chartData} layout="vertical" margin={{ left: 120 }}>
-          <XAxis type="number" tick={{ fontSize: 11 }} />
-          <YAxis type="category" dataKey="name" tick={{ fontSize: 11 }} width={110} />
-          <Tooltip contentStyle={{ borderRadius: '12px', border: 'none', boxShadow: '0 4px 20px rgba(0,0,0,.08)' }} />
-          <Bar dataKey="importance" fill="#6366f1" radius={[0, 6, 6, 0]} />
+      <ResponsiveContainer width="100%" height={320}>
+        <BarChart data={chartData} layout="vertical" margin={{ left: 110, right: 8 }}>
+          <XAxis type="number" tick={{ fontSize: 10, fill: 'var(--color-text-muted)' }} axisLine={false} tickLine={false} />
+          <YAxis type="category" dataKey="name" tick={{ fontSize: 10, fill: 'var(--color-text-secondary)' }} width={105} axisLine={false} tickLine={false} />
+          <Tooltip
+            contentStyle={{
+              background: 'var(--color-surface-raised)',
+              border: '1px solid var(--color-border-subtle)',
+              borderRadius: '8px',
+              fontSize: '11px',
+              color: 'var(--color-text-primary)',
+            }}
+          />
+          <Bar dataKey="importance" radius={[0, 4, 4, 0]}>
+            {chartData.map((entry, i) => (
+              <Cell key={i} fill={`rgba(76, 176, 80, ${0.3 + (entry.importance / maxVal) * 0.7})`} />
+            ))}
+          </Bar>
         </BarChart>
       </ResponsiveContainer>
     </div>

--- a/frontend/src/components/charts/RepaymentDistribution.tsx
+++ b/frontend/src/components/charts/RepaymentDistribution.tsx
@@ -1,25 +1,57 @@
-import { PieChart, Pie, Cell, ResponsiveContainer, Legend, Tooltip } from 'recharts';
+import { PieChart, Pie, Cell, ResponsiveContainer, Tooltip } from 'recharts';
 import { useApi } from '../../hooks/useApi';
 import { api } from '../../lib/api';
 
-const COLORS = ['#22c55e', '#ef4444'];
+const COLORS = ['#4CB050', '#E85D5D'];
 
 export default function RepaymentDistribution() {
   const { data, loading } = useApi(api.getRepayment);
-  if (loading || !data) return <div className="animate-pulse h-64 bg-gray-100 dark:bg-gray-800 rounded-xl" />;
+  if (loading || !data) return <div className="h-72 rounded-xl animate-shimmer" />;
+
+  const total = data.reduce((s, d) => s + d.count, 0);
 
   return (
-    <div className="bg-white dark:bg-gray-900 rounded-2xl p-6 shadow-sm border border-gray-100 dark:border-gray-800">
-      <h3 className="text-lg font-semibold text-gray-900 dark:text-gray-100 mb-4">Repayment Distribution</h3>
-      <ResponsiveContainer width="100%" height={280}>
-        <PieChart>
-          <Pie data={data} dataKey="count" nameKey="status" cx="50%" cy="50%" innerRadius={60} outerRadius={100} paddingAngle={4} strokeWidth={0}>
-            {data.map((_, i) => <Cell key={i} fill={COLORS[i % COLORS.length]} />)}
-          </Pie>
-          <Tooltip formatter={(value) => Number(value).toLocaleString()} contentStyle={{ borderRadius: '12px', border: 'none', boxShadow: '0 4px 20px rgba(0,0,0,.08)' }} />
-          <Legend />
-        </PieChart>
-      </ResponsiveContainer>
+    <div className="bg-surface-raised rounded-xl p-5 border border-border-subtle noise relative overflow-hidden card-hover">
+      <div className="absolute top-0 left-0 right-0 h-[2px] bg-pz-green" />
+      <p className="text-[10px] font-semibold uppercase tracking-[0.15em] text-text-muted mb-4">Repayment Distribution</p>
+      <div className="flex items-center">
+        <ResponsiveContainer width="55%" height={220}>
+          <PieChart>
+            <Pie data={data} dataKey="count" nameKey="status" cx="50%" cy="50%" innerRadius={55} outerRadius={85} paddingAngle={3} strokeWidth={0}>
+              {data.map((_, i) => <Cell key={i} fill={COLORS[i % COLORS.length]} />)}
+            </Pie>
+            <Tooltip
+              formatter={(value) => Number(value).toLocaleString()}
+              contentStyle={{
+                background: 'var(--color-surface-raised)',
+                border: '1px solid var(--color-border-subtle)',
+                borderRadius: '8px',
+                fontSize: '11px',
+                color: 'var(--color-text-primary)',
+              }}
+            />
+          </PieChart>
+        </ResponsiveContainer>
+        <div className="flex-1 space-y-3 pl-2">
+          {data.map((d, i) => (
+            <div key={d.status} className="flex items-center gap-3">
+              <div className="w-2.5 h-2.5 rounded-full shrink-0" style={{ background: COLORS[i] }} />
+              <div className="flex-1 min-w-0">
+                <p className="text-xs font-medium text-text-primary">{d.status}</p>
+                <p className="text-[11px] text-text-muted font-mono">
+                  {d.count} ({((d.count / total) * 100).toFixed(0)}%)
+                </p>
+              </div>
+            </div>
+          ))}
+          <div className="pt-2 border-t border-border-subtle">
+            <p className="text-[10px] text-text-muted">Avg defaulted loan</p>
+            <p className="text-xs font-mono font-medium text-danger">
+              KES {data.find(d => d.status === 'Defaulted')?.avg_loan_amount?.toLocaleString(undefined, { maximumFractionDigits: 0 }) ?? '—'}
+            </p>
+          </div>
+        </div>
+      </div>
     </div>
   );
 }

--- a/frontend/src/components/charts/RiskSegments.tsx
+++ b/frontend/src/components/charts/RiskSegments.tsx
@@ -4,7 +4,7 @@ import { api } from '../../lib/api';
 
 export default function RiskSegments() {
   const { data, loading } = useApi(api.getSegments);
-  if (loading || !data) return <div className="animate-pulse h-64 bg-gray-100 dark:bg-gray-800 rounded-xl" />;
+  if (loading || !data) return <div className="h-72 rounded-xl animate-shimmer" />;
 
   const chartData = data.map((d) => ({
     segment: d.risk_segment.replace('_', ' '),
@@ -13,17 +13,28 @@ export default function RiskSegments() {
   }));
 
   return (
-    <div className="bg-white dark:bg-gray-900 rounded-2xl p-6 shadow-sm border border-gray-100 dark:border-gray-800">
-      <h3 className="text-lg font-semibold text-gray-900 dark:text-gray-100 mb-4">Risk Segments</h3>
-      <ResponsiveContainer width="100%" height={280}>
-        <BarChart data={chartData}>
-          <XAxis dataKey="segment" tick={{ fontSize: 12 }} />
-          <YAxis yAxisId="left" tick={{ fontSize: 11 }} />
-          <YAxis yAxisId="right" orientation="right" tick={{ fontSize: 11 }} unit="%" />
-          <Tooltip contentStyle={{ borderRadius: '12px', border: 'none', boxShadow: '0 4px 20px rgba(0,0,0,.08)' }} />
-          <Legend />
-          <Bar yAxisId="left" dataKey="count" fill="#6366f1" radius={[6, 6, 0, 0]} name="Borrowers" />
-          <Bar yAxisId="right" dataKey="default_rate" fill="#ef4444" radius={[6, 6, 0, 0]} name="Default Rate %" />
+    <div className="bg-surface-raised rounded-xl p-5 border border-border-subtle noise relative overflow-hidden card-hover">
+      <div className="absolute top-0 left-0 right-0 h-[2px] bg-danger" />
+      <p className="text-[10px] font-semibold uppercase tracking-[0.15em] text-text-muted mb-4">Risk Segments</p>
+      <ResponsiveContainer width="100%" height={260}>
+        <BarChart data={chartData} barGap={6}>
+          <XAxis dataKey="segment" tick={{ fontSize: 11, fill: 'var(--color-text-secondary)' }} axisLine={false} tickLine={false} />
+          <YAxis yAxisId="left" tick={{ fontSize: 10, fill: 'var(--color-text-muted)' }} axisLine={false} tickLine={false} />
+          <YAxis yAxisId="right" orientation="right" tick={{ fontSize: 10, fill: 'var(--color-text-muted)' }} unit="%" axisLine={false} tickLine={false} />
+          <Tooltip
+            contentStyle={{
+              background: 'var(--color-surface-raised)',
+              border: '1px solid var(--color-border-subtle)',
+              borderRadius: '8px',
+              fontSize: '11px',
+              color: 'var(--color-text-primary)',
+            }}
+          />
+          <Legend
+            wrapperStyle={{ fontSize: '11px', color: 'var(--color-text-muted)' }}
+          />
+          <Bar yAxisId="left" dataKey="count" fill="#4CB050" radius={[4, 4, 0, 0]} name="Borrowers" opacity={0.85} />
+          <Bar yAxisId="right" dataKey="default_rate" fill="#E85D5D" radius={[4, 4, 0, 0]} name="Default Rate %" opacity={0.85} />
         </BarChart>
       </ResponsiveContainer>
     </div>

--- a/frontend/src/components/charts/TransactionFlows.tsx
+++ b/frontend/src/components/charts/TransactionFlows.tsx
@@ -4,7 +4,7 @@ import { api } from '../../lib/api';
 
 export default function TransactionFlows() {
   const { data, loading } = useApi(api.getTransactions);
-  if (loading || !data) return <div className="animate-pulse h-64 bg-gray-100 dark:bg-gray-800 rounded-xl" />;
+  if (loading || !data) return <div className="h-72 rounded-xl animate-shimmer" />;
 
   const chartData = data.monthly_flows.map((d) => ({
     month: d.month,
@@ -13,26 +13,36 @@ export default function TransactionFlows() {
   }));
 
   return (
-    <div className="bg-white dark:bg-gray-900 rounded-2xl p-6 shadow-sm border border-gray-100 dark:border-gray-800">
-      <h3 className="text-lg font-semibold text-gray-900 dark:text-gray-100 mb-4">Monthly Transaction Flows</h3>
-      <ResponsiveContainer width="100%" height={280}>
+    <div className="bg-surface-raised rounded-xl p-5 border border-border-subtle noise relative overflow-hidden card-hover">
+      <div className="absolute top-0 left-0 right-0 h-[2px] bg-pz-green" />
+      <p className="text-[10px] font-semibold uppercase tracking-[0.15em] text-text-muted mb-4">Monthly Transaction Flows</p>
+      <ResponsiveContainer width="100%" height={260}>
         <AreaChart data={chartData}>
           <defs>
-            <linearGradient id="inG" x1="0" y1="0" x2="0" y2="1">
-              <stop offset="5%" stopColor="#22c55e" stopOpacity={0.3} />
-              <stop offset="95%" stopColor="#22c55e" stopOpacity={0} />
+            <linearGradient id="inflowGrad" x1="0" y1="0" x2="0" y2="1">
+              <stop offset="0%" stopColor="#4CB050" stopOpacity={0.25} />
+              <stop offset="100%" stopColor="#4CB050" stopOpacity={0} />
             </linearGradient>
-            <linearGradient id="outG" x1="0" y1="0" x2="0" y2="1">
-              <stop offset="5%" stopColor="#ef4444" stopOpacity={0.3} />
-              <stop offset="95%" stopColor="#ef4444" stopOpacity={0} />
+            <linearGradient id="outflowGrad" x1="0" y1="0" x2="0" y2="1">
+              <stop offset="0%" stopColor="#E85D5D" stopOpacity={0.2} />
+              <stop offset="100%" stopColor="#E85D5D" stopOpacity={0} />
             </linearGradient>
           </defs>
-          <XAxis dataKey="month" tick={{ fontSize: 10 }} interval="preserveStartEnd" />
-          <YAxis tick={{ fontSize: 11 }} tickFormatter={(v) => `${(v / 1e6).toFixed(1)}M`} />
-          <Tooltip formatter={(v) => `KES ${Number(v).toLocaleString()}`} contentStyle={{ borderRadius: '12px', border: 'none', boxShadow: '0 4px 20px rgba(0,0,0,.08)' }} />
-          <Legend />
-          <Area type="monotone" dataKey="inflows" stroke="#22c55e" fill="url(#inG)" strokeWidth={2} name="Inflows" />
-          <Area type="monotone" dataKey="outflows" stroke="#ef4444" fill="url(#outG)" strokeWidth={2} name="Outflows" />
+          <XAxis dataKey="month" tick={{ fontSize: 9, fill: 'var(--color-text-muted)' }} interval="preserveStartEnd" axisLine={false} tickLine={false} />
+          <YAxis tick={{ fontSize: 10, fill: 'var(--color-text-muted)' }} tickFormatter={(v) => `${(v / 1e6).toFixed(1)}M`} axisLine={false} tickLine={false} />
+          <Tooltip
+            formatter={(v) => `KES ${Number(v).toLocaleString()}`}
+            contentStyle={{
+              background: 'var(--color-surface-raised)',
+              border: '1px solid var(--color-border-subtle)',
+              borderRadius: '8px',
+              fontSize: '11px',
+              color: 'var(--color-text-primary)',
+            }}
+          />
+          <Legend wrapperStyle={{ fontSize: '11px', color: 'var(--color-text-muted)' }} />
+          <Area type="monotone" dataKey="inflows" stroke="#4CB050" fill="url(#inflowGrad)" strokeWidth={2} name="Inflows" />
+          <Area type="monotone" dataKey="outflows" stroke="#E85D5D" fill="url(#outflowGrad)" strokeWidth={1.5} name="Outflows" strokeDasharray="4 2" />
         </AreaChart>
       </ResponsiveContainer>
     </div>

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -1,10 +1,111 @@
 @import "tailwindcss";
 
 @theme {
-  --color-primary: #6366f1;
-  --color-primary-light: #818cf8;
-  --color-primary-dark: #4f46e5;
-  --color-accent: #f59e0b;
-  --color-danger: #ef4444;
-  --color-success: #22c55e;
+  /* Pezesha brand */
+  --color-pz-green: #4CB050;
+  --color-pz-green-light: #6ECF72;
+  --color-pz-green-dark: #2E7D32;
+  --color-pz-green-muted: #4CB05015;
+  --color-pz-gray: #6D6E71;
+
+  /* Palette derived from brand */
+  --color-surface: #0B0F14;
+  --color-surface-raised: #141A22;
+  --color-surface-overlay: #1C2430;
+  --color-surface-glass: #141A2280;
+  --color-border-subtle: #1E2A36;
+  --color-border-accent: #2A3A48;
+  --color-text-primary: #E8ECF1;
+  --color-text-secondary: #8B96A5;
+  --color-text-muted: #5A6474;
+
+  /* Semantic */
+  --color-danger: #E85D5D;
+  --color-danger-muted: #E85D5D18;
+  --color-warning: #E8A84C;
+  --color-warning-muted: #E8A84C18;
+  --color-info: #4C9BE8;
+
+  /* Typography */
+  --font-sans: 'DM Sans', system-ui, sans-serif;
+  --font-mono: 'JetBrains Mono', ui-monospace, monospace;
+}
+
+/* Light mode overrides */
+.light {
+  --color-surface: #F5F7FA;
+  --color-surface-raised: #FFFFFF;
+  --color-surface-overlay: #F0F2F5;
+  --color-surface-glass: #FFFFFF90;
+  --color-border-subtle: #E2E6EB;
+  --color-border-accent: #D0D5DC;
+  --color-text-primary: #1A1F26;
+  --color-text-secondary: #5A6474;
+  --color-text-muted: #8B96A5;
+  --color-danger-muted: #E85D5D12;
+  --color-warning-muted: #E8A84C12;
+}
+
+html {
+  font-family: var(--font-sans);
+  -webkit-font-smoothing: antialiased;
+  -moz-osx-font-smoothing: grayscale;
+}
+
+body {
+  background: var(--color-surface);
+  color: var(--color-text-primary);
+}
+
+/* Scrollbar styling */
+::-webkit-scrollbar { width: 6px; height: 6px; }
+::-webkit-scrollbar-track { background: transparent; }
+::-webkit-scrollbar-thumb { background: var(--color-border-accent); border-radius: 3px; }
+::-webkit-scrollbar-thumb:hover { background: var(--color-pz-gray); }
+
+/* Custom animations */
+@keyframes fadeUp {
+  from { opacity: 0; transform: translateY(12px); }
+  to { opacity: 1; transform: translateY(0); }
+}
+
+@keyframes shimmer {
+  0% { background-position: -200% 0; }
+  100% { background-position: 200% 0; }
+}
+
+@keyframes pulse-ring {
+  0% { transform: scale(0.95); opacity: 0.5; }
+  50% { transform: scale(1); opacity: 1; }
+  100% { transform: scale(0.95); opacity: 0.5; }
+}
+
+.animate-fade-up {
+  animation: fadeUp 0.5s ease-out forwards;
+}
+
+.animate-shimmer {
+  background: linear-gradient(90deg, var(--color-surface-raised) 25%, var(--color-surface-overlay) 50%, var(--color-surface-raised) 75%);
+  background-size: 200% 100%;
+  animation: shimmer 1.8s infinite;
+}
+
+/* Noise texture overlay */
+.noise::after {
+  content: '';
+  position: absolute;
+  inset: 0;
+  opacity: 0.025;
+  background-image: url("data:image/svg+xml,%3Csvg viewBox='0 0 256 256' xmlns='http://www.w3.org/2000/svg'%3E%3Cfilter id='noise'%3E%3CfeTurbulence type='fractalNoise' baseFrequency='0.9' numOctaves='4' stitchTiles='stitch'/%3E%3C/filter%3E%3Crect width='100%25' height='100%25' filter='url(%23noise)'/%3E%3C/svg%3E");
+  pointer-events: none;
+  border-radius: inherit;
+}
+
+/* Card hover lift */
+.card-hover {
+  transition: transform 0.2s ease, box-shadow 0.2s ease;
+}
+.card-hover:hover {
+  transform: translateY(-2px);
+  box-shadow: 0 8px 32px rgba(0, 0, 0, 0.12);
 }


### PR DESCRIPTION
## Summary
- Redesign dashboard with Pezesha brand colors (green #4CB050, gray #6D6E71)
- Dark-first design with DM Sans + JetBrains Mono typography
- Colored top-edge card accents, noise textures, staggered fade-up animations
- Gradient-intensity bar fills, category-specific chart colors
- Pill-style nav with green glow, section labels with green markers
- Light mode toggle, custom scrollbars

## Test plan
- [x] `npm run build` succeeds
- [x] Server serves the new frontend at `/`
- [x] All 3 pages render (Dashboard, Risk Scorer, SQL Analysis)
- [x] Light/dark mode toggle works

Closes #17