### PR TITLE
Replace ASCII art with interactive Excalidraw diagrams

### DIFF
--- a/docs/patascore_strategy.md
+++ b/docs/patascore_strategy.md
@@ -32,26 +32,9 @@ Yet these same individuals transact daily through M-Pesa, pay for electricity th
 
 ### 2.1 Data Source Overview
 
-```
-+-------------------------------------------------------------------+
-|                     PataSCORE Data Sources                         |
-+-------------------------------------------------------------------+
-|                                                                   |
-|  +-------------+  +-------------+  +-------------+               |
-|  | Mobile Money|  |   Utility   |  |   Device &  |               |
-|  | (M-Pesa,   |  |  Payments   |  |  Behavioral |               |
-|  |  Airtel $) |  |  (KPLC,    |  |   Signals   |               |
-|  |            |  |   Water)    |  |             |               |
-|  +------+------+  +------+------+  +------+------+               |
-|         |                |                |                       |
-|  +------+------+  +------+------+  +------+------+               |
-|  | E-Commerce  |  |   Social   |  |   GPS &    |               |
-|  | & Digital   |  |   Media    |  |  Location  |               |
-|  |  Payments   |  |  Signals   |  |   Data     |               |
-|  +-------------+  +-------------+  +-------------+               |
-|                                                                   |
-+-------------------------------------------------------------------+
-```
+[![PataSCORE Data Sources](https://img.shields.io/badge/View_Diagram-Excalidraw-6965db)](https://excalidraw.com/#json=3qJDccV2BouzxSrvsx8Hl,bXNN16H4yxe0Yz9177lnrw)
+
+> **[Open interactive diagram](https://excalidraw.com/#json=3qJDccV2BouzxSrvsx8Hl,bXNN16H4yxe0Yz9177lnrw)** — 6 data sources: Mobile Money (15 features, 35-40%), Utility Payments (5, 10-15%), Device & Behavioral (7, 15-20%), E-Commerce (5, 5-10%), Social Media (4, 5%), GPS & Location (5, 10-15%) → ~41 total features across 3 scoring tiers
 
 ### 2.2 Source 1: Mobile Money Transactions (M-Pesa, Airtel Money)
 
@@ -194,42 +177,9 @@ Yet these same individuals transact daily through M-Pesa, pay for electricity th
 
 ### 3.1 Feature Processing Architecture
 
-```
-Raw Data Sources (6 streams)
-         |
-         v
-+---------------------+
-| Feature Extraction   |
-| (per-source ETL)     |
-+----------+----------+
-           |
-           v
-+---------------------+
-| Feature Store        |
-| (Redis + DynamoDB)   |
-|                      |
-| Namespaces:          |
-|  mobile_money.*      |
-|  utility.*           |
-|  device.*            |
-|  social.*            |
-|  ecommerce.*         |
-|  location.*          |
-+----------+----------+
-           |
-           v
-+---------------------+
-| Feature Assembly     |
-| (join by customer_id)|
-| ~60 features total   |
-+----------+----------+
-           |
-     +-----+-----+
-     |           |
-     v           v
- [Training]  [Serving]
-  (batch)    (real-time)
-```
+[![Feature Processing Architecture](https://img.shields.io/badge/View_Diagram-Excalidraw-6965db)](https://excalidraw.com/#json=HelHdGKaesIGv0njEFdEC,8vCoPhZWUFL7_NgICrgZag)
+
+> **[Open interactive diagram](https://excalidraw.com/#json=HelHdGKaesIGv0njEFdEC,8vCoPhZWUFL7_NgICrgZag)** — Raw Data Sources → Feature Extraction (per-source ETL) → Feature Store (Redis + DynamoDB, 6 namespaces) → Feature Assembly (join by customer_id, ~41 features) → Training (batch) + Serving (real-time)
 
 ### 3.2 Feature Categories and Weights
 
@@ -276,50 +226,9 @@ The model is trained separately for each tier, so a Tier 1 score is calibrated a
 
 PataSCORE uses a **stacked ensemble** combining gradient boosting and a neural network, each with distinct strengths:
 
-```
-                   Input Features (~41 features)
-                          |
-             +------------+------------+
-             |                         |
-             v                         v
-    +------------------+    +--------------------+
-    | LightGBM         |    | Feed-Forward       |
-    | (Gradient Boost)  |    | Neural Network     |
-    |                  |    |                    |
-    | - Handles nulls  |    | - Captures non-    |
-    |   natively       |    |   linear feature   |
-    | - Fast training  |    |   interactions     |
-    | - Built-in       |    | - Embedding layers |
-    |   feature        |    |   for categorical  |
-    |   importance     |    |   features         |
-    | - Robust to      |    | - Batch norm for   |
-    |   outliers       |    |   stability        |
-    +--------+---------+    +--------+-----------+
-             |                         |
-             v                         v
-        P(default)_gbm           P(default)_nn
-             |                         |
-             +------------+------------+
-                          |
-                          v
-               +--------------------+
-               | Meta-Learner       |
-               | (Logistic          |
-               |  Regression)       |
-               |                    |
-               | Inputs:            |
-               | - P(default)_gbm   |
-               | - P(default)_nn    |
-               | - score_tier       |
-               | - data_completeness|
-               +--------+-----------+
-                        |
-                        v
-                  Final P(default)
-                        |
-                        v
-                  PataSCORE (300-850)
-```
+[![Ensemble Model Architecture](https://img.shields.io/badge/View_Diagram-Excalidraw-6965db)](https://excalidraw.com/#json=Ne0glL475qIsMFzL2PzfL,dLcpzpLIyQ2A5307lmeQ-Q)
+
+> **[Open interactive diagram](https://excalidraw.com/#json=Ne0glL475qIsMFzL2PzfL,dLcpzpLIyQ2A5307lmeQ-Q)** — Input Features (~41) → LightGBM + Neural Network (dual base models) → Meta-Learner (Logistic Regression with score_tier + data_completeness) → Final P(default) → PataSCORE (300-850)
 
 ### 4.2 LightGBM Component
 
@@ -547,26 +456,9 @@ PataSCORE must comply with:
 
 ### 6.3 Consent Framework
 
-```
-+-------------------------------------------------------------------+
-|                      Consent Flow                                  |
-+-------------------------------------------------------------------+
-|                                                                   |
-|  1. User opens loan application                                   |
-|  2. Clear disclosure: "We will access your M-Pesa history,        |
-|     utility records, and device information to assess your         |
-|     creditworthiness"                                              |
-|  3. Granular consent toggles:                                      |
-|     [x] M-Pesa transaction history (required)                     |
-|     [ ] KPLC payment records (optional, improves score)            |
-|     [ ] Device information (optional, improves score)              |
-|     [ ] Location data (optional, improves score)                   |
-|  4. User explicitly accepts or declines each source                |
-|  5. Consent receipt stored with timestamp and version              |
-|  6. User can revoke consent at any time via app settings           |
-|                                                                   |
-+-------------------------------------------------------------------+
-```
+[![Consent Flow](https://img.shields.io/badge/View_Diagram-Excalidraw-6965db)](https://excalidraw.com/#json=tIIm6Yt5XMciATHfKv619,NgHx5UcR1gUAjQ7vBoabMw)
+
+> **[Open interactive diagram](https://excalidraw.com/#json=tIIm6Yt5XMciATHfKv619,NgHx5UcR1gUAjQ7vBoabMw)** — 5-step DPA 2019 consent flow: Open loan application → Clear disclosure → Granular consent toggles (M-Pesa required, KPLC/Device/Location optional) → Accept/Decline decision → Store consent receipt + timestamp. User can revoke at any time.
 
 ### 6.4 Bias Monitoring and Fairness
 
@@ -851,55 +743,9 @@ PataSCORE is a tool for inclusion, not predation. Safeguards include:
 
 ## 9. Technical Architecture Summary
 
-```
-+-----------------------------------------------------------------------+
-|                        PataSCORE System                                |
-+-----------------------------------------------------------------------+
-|                                                                       |
-|  DATA LAYER                                                           |
-|  +-----------+  +-----------+  +-----------+  +-----------+          |
-|  | Daraja    |  | KPLC API  |  | Device    |  | OAuth     |          |
-|  | API       |  |           |  | SDK       |  | Social    |          |
-|  | (M-Pesa)  |  | (Utility) |  | (Android) |  | (Meta/LI) |          |
-|  +-----+-----+  +-----+-----+  +-----+-----+  +-----+-----+          |
-|        |              |              |              |                  |
-|        +------+-------+------+-------+------+-------+                  |
-|               |              |              |                          |
-|  PROCESSING   v              v              v                          |
-|  +------------------+  +------------------+  +------------------+     |
-|  | Feature          |  | Consent          |  | Data Quality     |     |
-|  | Extraction       |  | Manager          |  | Validator        |     |
-|  | (PySpark/Python) |  | (DPA 2019)       |  | (Great Expects.) |     |
-|  +--------+---------+  +------------------+  +------------------+     |
-|           |                                                           |
-|  STORAGE  v                                                           |
-|  +------------------+  +------------------+                           |
-|  | Feature Store    |  | Score History     |                          |
-|  | (Redis+DynamoDB) |  | (PostgreSQL)     |                          |
-|  +--------+---------+  +------------------+                           |
-|           |                                                           |
-|  MODEL    v                                                           |
-|  +------------------+  +------------------+  +------------------+     |
-|  | LightGBM         |  | Neural Network   |  | Meta-Learner     |     |
-|  | (Base Model 1)   |  | (Base Model 2)   |  | (Stacking)       |     |
-|  +--------+---------+  +--------+---------+  +--------+---------+     |
-|           |                     |                     |               |
-|  SERVING  +---------------------+---------------------+               |
-|           |                                                           |
-|           v                                                           |
-|  +------------------+  +------------------+  +------------------+     |
-|  | Scoring API      |  | Explainability   |  | Fairness         |     |
-|  | (FastAPI + ONNX) |  | (SHAP Engine)    |  | Monitor          |     |
-|  +--------+---------+  +------------------+  +------------------+     |
-|           |                                                           |
-+-----------------------------------------------------------------------+
-            |
-            v
-    +---------------+
-    | Lender APIs   |
-    | (REST/gRPC)   |
-    +---------------+
-```
+[![PataSCORE System Architecture](https://img.shields.io/badge/View_Diagram-Excalidraw-6965db)](https://excalidraw.com/#json=GMMSZd028XU_tOaJ7S9O1,Eo07HGgMRIlBeTcVz1ZGpQ)
+
+> **[Open interactive diagram](https://excalidraw.com/#json=GMMSZd028XU_tOaJ7S9O1,Eo07HGgMRIlBeTcVz1ZGpQ)** — 5-layer architecture: Data Layer (Daraja API, KPLC, Device SDK, OAuth, E-Commerce) → Processing (Feature Extraction, Consent Manager, Data Quality) → Storage (Feature Store, Score History) → Model (LightGBM + Neural Network + Meta-Learner) → Serving (Scoring API, SHAP Explainability, Fairness Monitor) → Lender APIs
 
 ---
 

--- a/docs/realtime_strategy.md
+++ b/docs/realtime_strategy.md
@@ -8,33 +8,9 @@
 
 Credit Pulse currently operates as a **batch-oriented pipeline** built on lightweight, local-first tooling:
 
-```
-CSV/XLSX Files
-    |
-    v
-[Ingest Pipeline]  -- Python + DuckDB
-    |                  (pipelines/flows/ingest.py)
-    v
-[DuckDB]  -- Embedded OLAP database
-    |        (credit_pulse.duckdb)
-    v
-[dbt Transformations]  -- Staging -> Intermediate -> Marts
-    |                     (dbt_project/models/)
-    |   stg_mpesa_transactions    -->  int_transaction_features
-    |   stg_loan_repayments       -->  int_borrower_profiles
-    |                                       |
-    |                                       v
-    |                              mart_credit_features
-    |                              mart_risk_segments
-    v
-[Model Training]  -- scikit-learn, XGBoost
-    |                (backend/services/credit_model.py)
-    v
-[FastAPI Serving]  -- /api/score endpoint
-    |                 (backend/api/routes/scoring.py)
-    v
-[React Dashboard]  -- Vite + React frontend
-```
+[![Current Batch Architecture](https://img.shields.io/badge/View_Diagram-Excalidraw-6965db)](https://excalidraw.com/#json=8E_8ur5jMLR6OydslXZMH,LqWfAWhw2ycAYYou4rAurw)
+
+> **[Open interactive diagram](https://excalidraw.com/#json=8E_8ur5jMLR6OydslXZMH,LqWfAWhw2ycAYYou4rAurw)** — CSV/XLSX Files → Ingest Pipeline → DuckDB → dbt Transformations → Model Training → FastAPI + React UI
 
 **Current stack summary:**
 
@@ -63,66 +39,9 @@ CSV/XLSX Files
 
 ### 2.1 Architecture Overview
 
-```
-                           +------------------+
-                           |  Data Sources    |
-                           |  - M-Pesa API    |
-                           |  - Loan Systems  |
-                           |  - Safaricom SDK |
-                           +--------+---------+
-                                    |
-                           (Events via webhooks/CDC)
-                                    |
-                                    v
-                    +-------------------------------+
-                    |       Apache Kafka             |
-                    |  +----------+ +-------------+  |
-                    |  | mpesa.   | | loan.       |  |
-                    |  | txns.raw | | events.raw  |  |
-                    |  +----------+ +-------------+  |
-                    |  | features | | risk.scores |  |
-                    |  | .computed| | .updates    |  |
-                    |  +----------+ +-------------+  |
-                    +------+--------+--------+-------+
-                           |        |        |
-              +------------+   +----+----+   +----------+
-              |                |         |              |
-              v                v         v              v
-     +-----------------+ +----------+ +----------+ +----------+
-     | PySpark         | | Schema   | | Great    | | Kafka    |
-     | Structured      | | Registry | | Expects. | | Connect  |
-     | Streaming       | | (Avro)   | | (DQ)     | | (S3 Sink)|
-     +---------+-------+ +----------+ +----------+ +----+-----+
-               |                                        |
-               |  (computed features)                   | (raw archival)
-               v                                        v
-     +-----------------+                      +------------------+
-     | Feature Store   |                      | Data Lake (S3/   |
-     | (Redis Cluster  |                      | MinIO) - Parquet |
-     |  + DynamoDB)    |                      +------------------+
-     +--------+--------+
-              |
-              |  (low-latency feature lookup)
-              v
-     +-----------------+     +--------------------+
-     | Model Serving   |<--->| Model Registry     |
-     | FastAPI + ONNX  |     | (MLflow)           |
-     | / TF Serving    |     +--------------------+
-     +--------+--------+
-              |
-              v
-     +-----------------+
-     | API Gateway /   |
-     | Load Balancer   |
-     +--------+--------+
-              |
-     +--------+--------+
-     | Consumers:      |
-     | - Credit apps   |
-     | - Risk dashbd   |
-     | - Loan origina. |
-     +-----------------+
-```
+[![Real-Time Architecture](https://img.shields.io/badge/View_Diagram-Excalidraw-6965db)](https://excalidraw.com/#json=fIMErdrYbYpxAmVfXcfwe,Hexu-0i7_0DP9PKpD2dRfw)
+
+> **[Open interactive diagram](https://excalidraw.com/#json=fIMErdrYbYpxAmVfXcfwe,Hexu-0i7_0DP9PKpD2dRfw)** — 5-layer architecture: Ingestion (M-Pesa API, Loan Systems, Safaricom SDK) → Streaming (Kafka, PySpark, Schema Registry) → Storage (Redis, DynamoDB, S3) → Serving (FastAPI + ONNX, MLflow, Kubernetes) → Monitoring (Prometheus, Grafana, Great Expectations, PagerDuty)
 
 ### 2.2 Component Breakdown
 
@@ -585,18 +504,9 @@ def validate_micro_batch(batch_df, batch_id):
 
 ### 8.2 Operational Monitoring Stack
 
-```
-+-----------------+     +------------+     +------------+
-| Spark Metrics   |---->| Prometheus |---->| Grafana    |
-| Kafka Metrics   |     |            |     | Dashboards |
-| App Metrics     |     +-----+------+     +-----+------+
-+-----------------+           |                   |
-                              v                   v
-                      +-------+-------+   +-------+------+
-                      | AlertManager  |   | PagerDuty /  |
-                      | (Thresholds)  |   | Slack Alerts |
-                      +---------------+   +--------------+
-```
+[![Monitoring & Alerting Stack](https://img.shields.io/badge/View_Diagram-Excalidraw-6965db)](https://excalidraw.com/#json=sdvv9OhQ3B4Aeg8F6ZvQF,kwpVJ1UbYtiVGBiBYjKeXA)
+
+> **[Open interactive diagram](https://excalidraw.com/#json=sdvv9OhQ3B4Aeg8F6ZvQF,kwpVJ1UbYtiVGBiBYjKeXA)** — Metric Sources (Spark, Kafka, FastAPI) → Prometheus → Grafana / AlertManager → PagerDuty + Slack, with Great Expectations (DQ) and Evidently AI (drift detection)
 
 **Key metrics to monitor:**
 
@@ -786,17 +696,9 @@ spec:
 
 Run batch and streaming pipelines in parallel. The batch pipeline remains the source of truth.
 
-```
-Current Batch Pipeline  ------>  DuckDB  ------>  FastAPI (joblib)
-         |                                              |
-         +-- (mirror events to Kafka) -->  Kafka        |
-                                             |          |
-                                        Spark Stream    |
-                                             |          |
-                                        Redis (shadow)  |
-                                             |          |
-                                      [Compare outputs] <--+
-```
+[![Migration Strategy](https://img.shields.io/badge/View_Diagram-Excalidraw-6965db)](https://excalidraw.com/#json=lZg9KzxyrIC__CB3jhl8u,OnNsM8V5DDB0E4aw5VmxTQ)
+
+> **[Open interactive diagram](https://excalidraw.com/#json=lZg9KzxyrIC__CB3jhl8u,OnNsM8V5DDB0E4aw5VmxTQ)** — 4-phase migration: Phase 1 Dual-Write (batch + shadow streaming) → Phase 2 Shadow Scoring (ONNX, log-only) → Phase 3 Gradual Cutover (5% → 25% → 50% → 100%) → Phase 4 Optimization
 
 **Key activities:**
 - Deploy Kafka and produce events alongside batch ingestion


### PR DESCRIPTION
## Summary

- Replace 9 ASCII art diagrams across both strategy docs with interactive Excalidraw links
- Each diagram includes a clickable badge and descriptive summary for context without clicking
- 4 diagrams in `docs/realtime_strategy.md` (batch arch, real-time arch, monitoring, migration)
- 5 diagrams in `docs/patascore_strategy.md` (data sources, feature pipeline, ensemble, consent flow, system arch)

## Test plan

- [ ] Verify all 9 Excalidraw links open correctly in browser
- [ ] Confirm descriptive summaries accurately reflect diagram content
- [ ] Check markdown renders properly on GitHub

Closes #21